### PR TITLE
fix(seats): request a virtual display and retry detection after client connect

### DIFF
--- a/src/MultiSeat.Service/Monitoring/SessionHealthCheck.cs
+++ b/src/MultiSeat.Service/Monitoring/SessionHealthCheck.cs
@@ -194,6 +194,24 @@ public sealed class SessionHealthCheck
         // since the previous tick. Does not change seat state here.
         _onConnectApps.ProcessSeat(seat, ct);
 
+        // ── Late SudoVDA detection ────────────────────────────────
+        // Apollo creates the seat's virtual display when a client connects, not at startup,
+        // so provisioning's one-shot lookup always misses it and display isolation gets
+        // skipped for the seat's whole life. Retry here until it appears. No-op once
+        // DisplayDevicePath is set, and silent while there is still nothing to find.
+        if (string.IsNullOrEmpty(seat.DisplayDevicePath))
+        {
+            try
+            {
+                if (await _seatManager.TryLateDisplayDetectionAsync(seat, ct))
+                    return true; // DisplayDevicePath changed — worth broadcasting
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Seat {Id}: late display detection failed", seat.Id);
+            }
+        }
+
         return false; // no state change
     }
 

--- a/src/MultiSeat.Service/Sessions/SeatManager.cs
+++ b/src/MultiSeat.Service/Sessions/SeatManager.cs
@@ -564,6 +564,72 @@ public sealed class SeatManager
     /// 1024×768 — even though Apollo logs request 1920×1080.
     /// Both steps are best-effort; failures are logged and ignored.
     /// </summary>
+    /// <summary>
+    /// Second chance at finding the seat's SudoVDA display, run from the health-check tick.
+    ///
+    /// Provisioning looks for the display ~5s after Apollo starts, but Apollo does not create
+    /// one then. Creation happens in its <c>proc_t::execute()</c> — i.e. when a client connects
+    /// and launches an app — gated on <c>headless_mode</c> (which ApolloConfigBuilder now sets).
+    /// At provisioning time there is therefore nothing to find, DisplayDevicePath stays null,
+    /// and display isolation is skipped for the seat's whole life, leaving TermService CPU high.
+    ///
+    /// So retry while the seat runs. Once Apollo creates the display it logs a fresh
+    /// "Currently available display devices:" block, this picks it up, and isolation is applied.
+    ///
+    /// Deliberately does NOT restart Apollo the way the provisioning path does: a client is
+    /// streaming by the time this succeeds, and Apollo has already pointed itself at the new
+    /// display (it assigns config::video.output_name after creating it). Writing output_name to
+    /// the config here only makes the next start target it directly.
+    ///
+    /// Returns true when the display was found and isolation was attempted.
+    /// </summary>
+    public async Task<bool> TryLateDisplayDetectionAsync(SeatInfo seat, CancellationToken ct)
+    {
+        if (!string.IsNullOrEmpty(seat.DisplayDevicePath)) return false; // already known
+        if (seat.ApolloProcessId <= 0) return false;                     // Apollo not running
+
+        string text;
+        try
+        {
+            var logPath = _apolloManager.GetLogPath(seat.AccountName, _options.ApolloConfigDir);
+            if (!File.Exists(logPath)) return false;
+
+            // Apollo holds the log open, so share read AND write.
+            using var fs = new FileStream(
+                logPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var sr = new StreamReader(fs);
+            text = await sr.ReadToEndAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Seat {Id}: late display detection could not read Apollo log", seat.Id);
+            return false;
+        }
+
+        // ParseSudoVdaDisplayIdFromLogText matches the FIRST display block, which is Apollo's
+        // startup enumeration — exactly the one that never contains the virtual display. Slice
+        // from the last block so we parse Apollo's most recent view instead.
+        const string marker = "Currently available display devices:";
+        var last = text.LastIndexOf(marker, StringComparison.Ordinal);
+        if (last < 0) return false;
+
+        var result = ApolloManager.ParseSudoVdaDisplayIdFromLogText(text[last..]);
+        if (result.DeviceId is null) return false; // still nothing — stay quiet, we run every tick
+
+        seat.DisplayDevicePath = result.DeviceId;
+
+        var configPath = _apolloManager.GetConfigPath(seat.Id);
+        if (configPath is not null)
+            _configBuilder.UpdateDisplayOutput(configPath, result.DeviceId);
+
+        _logger.LogInformation(
+            "Seat {Id}: SudoVDA display found after client connect ({Dev}) — applying display isolation",
+            seat.Id, result.DeviceId);
+
+        await ApplyDisplayIsolationAsync(seat, ct);
+        return true;
+    }
+
     public async Task ApplyDisplayIsolationAsync(SeatInfo seat, CancellationToken ct)
     {
         var helperExe = Path.Combine(AppContext.BaseDirectory, "MultiSeat.Service.exe");

--- a/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
+++ b/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
@@ -146,6 +146,21 @@ public sealed class ApolloConfigBuilder
         sb.AppendLine("dd_refresh_rate_option = auto");
         sb.AppendLine();
 
+        // ── Force a virtual display for the seat ──────────────────────
+        // The dd_* keys above only configure a virtual display that already exists;
+        // nothing above causes Apollo to CREATE one. Apollo gates creation on
+        // (process.cpp): headless_mode || client-requested || per-app virtual_display
+        // || !allow_encoder_probing(). Inside an RDP-loopback seat the RDP surface is an
+        // active display, so encoder probing succeeds and none of the other triggers fire
+        // — Apollo creates nothing and the seat silently captures the RDP desktop instead
+        // (SeatManager then logs "SudoVDA display not found in Apollo log").
+        // headless_mode is the only trigger that is a config key, so it is the one we can
+        // set from here: "When enabled, all apps will start in virtual display."
+        sb.AppendLine("# Headless — force every app into a virtual display. Without this,");
+        sb.AppendLine("# Apollo never creates SudoVDA in an RDP seat and captures the RDP surface.");
+        sb.AppendLine("headless_mode = enabled");
+        sb.AppendLine();
+
         // ── Encoder ───────────────────────────────────────────────────
         // Prefer NVENC for hardware-accelerated low-latency encoding.
         // Apollo will fall back to AMF → software if NVENC is unavailable.


### PR DESCRIPTION
## Problem

Seats have always captured the **RDP surface** rather than an isolated virtual display. `SeatManager` reports it as:

```
SudoVDA display not found in Apollo log — streaming will capture primary monitor instead of virtual display
```

Consequences: display isolation never runs, so the RDP adapter is never shrunk to 640×480 and TermService CPU stays high; and the seat streams at the RDP surface's synthetic **1000 Hz**, which breaks games that need a real refresh rate.

This predates the recent Apollo fork swap — the same warning appears in logs from before it.

## Two independent causes

**1. Nothing ever asked Apollo to create a display.** The `dd_*` keys we write only *configure* a display that already exists. Apollo gates *creation* (`process.cpp`) on:

```cpp
headless_mode || launch_session->virtual_display || _app.virtual_display || !video::allow_encoder_probing()
```

Inside an RDP seat the RDP surface **is** an active display, so encoder probing succeeds and none of the triggers fire. `headless_mode` is the only trigger that is a config key, so `ApolloConfigBuilder` now sets it.

**2. Detection ran at the wrong time.** Provisioning looked for the display ~5 s after Apollo starts, but creation happens on **client connect** — so the lookup was structurally guaranteed to miss, and `DisplayDevicePath` stayed null for the seat's whole life. Detection now retries from the health-check tick and applies isolation when the display appears.

Note the retry parses the **last** `"Currently available display devices:"` block. `ParseSudoVdaDisplayIdFromLogText` takes the *first*, which is Apollo's startup enumeration — precisely the one that never contains a virtual display.

## Honest status: correct, but currently inert

Both changes are verified in the Apollo log (`headless_mode=true`, gate opens, `SudoVDA status is OK`, `AddVirtualDisplay()` succeeds) — but **they do not yet produce a virtual display**, because Windows does not allow a console indirect display driver to join an RDP session's topology.

Per [Microsoft's IddCx remote IDD documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/display/iddcx1.4-updates-for-remote-idds), in a WDDM remote session:

| API | Behaviour |
|---|---|
| `QueryDisplayConfig` | Works |
| `SetDisplayConfig` | **Fails** |
| `ChangeDisplaySettings` | *"Returns success for application compatibility reasons, but ignores the call"* |

Which matches `sudovda-activate.log` exactly — `topology-extend fallback result=0` (success, no effect) ×69, and the SudoVDA target never appearing among the session's 256 enumerated paths. Only a driver declaring `IDDCX_ADAPTER_FLAGS_REMOTE_SESSION_DRIVER`, loaded by the RDP stack, may change a remote session's display config, and only via `IddCxDisplayConfigUpdate`.

So this PR removes two real blockers and leaves one that needs driver or architecture work. Both changes cost nothing meanwhile and will take effect if that ever becomes possible.

## Testing

- Built clean (`dotnet build -c Release`, 0 errors)
- Deployed via `scripts\install-service.ps1`; seat re-provisioned repeatedly
- Confirmed `headless_mode = enabled` reaches the generated per-seat `sunshine.conf` and is read by Apollo
- Confirmed the retry runs silently while there is nothing to find (no log spam at the 5 s tick)
- Ruled out a timing explanation: Apollo's activation budget was temporarily raised 5 s → 15 s and failed identically at 15020 ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
