### PR TITLE
fix(input): the jail probe reads which failure it was, not whether it failed

### DIFF
--- a/src/MultiSeat.Service/Diagnostics/HidHideInspector.cs
+++ b/src/MultiSeat.Service/Diagnostics/HidHideInspector.cs
@@ -111,7 +111,15 @@ public static class HidHideInspector
             Console.WriteLine($"    HID parent  : {hidParent ?? "<unknown>"}");
             Console.WriteLine($"    XUSB parent : {xusbParent ?? "<unknown>"}   <- ROOT\\... here means emulated");
             Console.WriteLine($"    verdict     : {(emulated ? "EMULATED (ours to confine)" : "physical (left alone)")}");
-            Console.WriteLine($"    session 0 can open it: {HidHideSessionJail.CanOpen(pad.SymbolicLink)}");
+            var probe = HidHideSessionJail.Probe(pad.SymbolicLink);
+            Console.WriteLine($"    session 0 probe: {probe.Verdict}" +
+                              (probe.Error == 0 ? "" : $" (win32 {probe.Error})") +
+                              probe.Verdict switch
+                              {
+                                  HidHideSessionJail.JailProbe.Open => "   <- openable here, so no jail is in effect",
+                                  HidHideSessionJail.JailProbe.Confined => "   <- refused, which is what a live jail looks like",
+                                  _ => "   <- not a refusal, so nothing is proved either way",
+                              });
             Console.WriteLine($"    rules a jail to session N would write:");
             foreach (var rule in HidHideSessionJail.ConfineAll(pad, 99))
                 Console.WriteLine($"       --dev-hide \"{rule.Replace("!99", "!<N>")}\"");

--- a/src/MultiSeat.Service/Input/HidHideConfigurator.cs
+++ b/src/MultiSeat.Service/Input/HidHideConfigurator.cs
@@ -355,27 +355,47 @@ public sealed class HidHideConfigurator
     /// ⚠️ What it proves is one-directional: a refusal here means session 0 is being denied. It
     /// does not prove the seat can still see the pad — a plain global hide, or a rule whose suffix
     /// was stripped, would look exactly the same from here.
+    ///
+    /// ⚠️ And it is the KIND of failure that answers, not the fact of one. A jail refuses with
+    /// <c>ERROR_ACCESS_DENIED</c>; an absent device fails with <c>ERROR_FILE_NOT_FOUND</c>. Only
+    /// the first is evidence — see <see cref="HidHideSessionJail.Probe"/>.
     /// </summary>
     private void VerifyJail(SeatInfo seat, HidHideDevice pad)
     {
         if (!_options.VerifyHidHideJail) return;
         if (string.IsNullOrWhiteSpace(pad.SymbolicLink)) return;
 
-        if (HidHideSessionJail.CanOpen(pad.SymbolicLink))
+        var probe = HidHideSessionJail.Probe(pad.SymbolicLink);
+
+        switch (probe.Verdict)
         {
-            _logger.LogWarning(
-                "Seat {Id}: jail rules were written but session 0 can still open '{Pad}'. The " +
-                "confinement is NOT in effect — either cloaking is off, an application whitelist " +
-                "entry is defeating it, or this HidHide build no longer honours the '!<session>' " +
-                "suffix (it is undocumented). Gamepad input is not isolated.",
-                seat.Id, pad.FriendlyName);
-        }
-        else
-        {
-            _logger.LogInformation(
-                "Seat {Id}: verified — session 0 is refused '{Pad}', which is what a live jail " +
-                "looks like from outside it.",
-                seat.Id, pad.FriendlyName);
+            case HidHideSessionJail.JailProbe.Open:
+                _logger.LogWarning(
+                    "Seat {Id}: jail rules were written but session 0 can still open '{Pad}'. The " +
+                    "confinement is NOT in effect — either cloaking is off, an application whitelist " +
+                    "entry is defeating it, or this HidHide build no longer honours the '!<session>' " +
+                    "suffix (it is undocumented). Gamepad input is not isolated.",
+                    seat.Id, pad.FriendlyName);
+                break;
+
+            case HidHideSessionJail.JailProbe.Confined:
+                _logger.LogInformation(
+                    "Seat {Id}: verified — session 0 is refused '{Pad}', which is what a live jail " +
+                    "looks like from outside it.",
+                    seat.Id, pad.FriendlyName);
+                break;
+
+            default:
+                // NOT a success. Nobody can open a device that is not there, so this says nothing
+                // about the rule — and reporting it as a working jail is how a rule that matches
+                // nothing gets recorded as one being enforced.
+                _logger.LogWarning(
+                    "Seat {Id}: could not verify the jail on '{Pad}' — opening it failed with " +
+                    "Win32 error {Error}, which is not a refusal (a jail gives {Denied}). The " +
+                    "device is most likely gone, so the rules that were written may match nothing. " +
+                    "Nothing was proved either way.",
+                    seat.Id, pad.FriendlyName, probe.Error, HidHideSessionJail.ERROR_ACCESS_DENIED);
+                break;
         }
     }
 

--- a/src/MultiSeat.Service/Input/HidHideSessionJail.cs
+++ b/src/MultiSeat.Service/Input/HidHideSessionJail.cs
@@ -24,7 +24,7 @@ namespace MultiSeat.Service.Input;
 /// Two consequences fall straight out of that line and both are load-bearing:
 ///
 ///   * <b>Session 0 never matches</b>, so a service running there can use "can I still open this
-///     device?" as a live probe that a rule took effect — see <see cref="CanOpen"/>. Worth having
+///     device?" as a live probe that a rule took effect — see <see cref="Probe"/>. Worth having
 ///     for a feature that is undocumented and could be dropped by a future release without a word.
 ///   * On a session match <c>Blacklisted()</c> returns FALSE, so the <b>whitelist is never
 ///     consulted</b> for a confined device. That removes the whitelist's global-hole problem for
@@ -136,17 +136,61 @@ public static class HidHideSessionJail
     }
 
     /// <summary>
-    /// Can this process open the device right now? Run from the service (session 0) it is a live
-    /// check that a jail rule really took effect: session 0 never matches the jail, so a confined
-    /// device must become unopenable here while staying open inside its seat.
-    ///
-    /// Note what this does and does not prove. A false says session 0 is being refused, which is
-    /// what a working rule looks like from here — it does NOT prove the seat can still see the
-    /// pad. A plain global hide (or a rule whose suffix was stripped) produces the same false.
+    /// What a session-0 probe of a device found.
     /// </summary>
-    public static bool CanOpen(string symbolicLink)
+    public enum JailProbe
     {
-        if (string.IsNullOrWhiteSpace(symbolicLink)) return false;
+        /// <summary>The device opened. Whatever is on paper, the confinement is not in effect.</summary>
+        Open,
+
+        /// <summary>
+        /// The open was <b>refused</b>. Session 0 can never match a jail, so this is what a live
+        /// rule looks like from outside it.
+        /// </summary>
+        Confined,
+
+        /// <summary>
+        /// The open failed, but nothing refused it — most often the device is simply not there.
+        /// Nothing was proved either way.
+        ///
+        /// <para>Kept apart from <see cref="Confined"/> deliberately: see <see cref="Probe"/>.</para>
+        /// </summary>
+        Unreachable,
+    }
+
+    /// <summary>One probe: the verdict, and the Win32 error that produced it (0 when it opened).</summary>
+    public readonly record struct JailProbeResult(JailProbe Verdict, int Error);
+
+    /// <summary>
+    /// Ask, from this process's session, whether the device can still be opened.
+    ///
+    /// Run from the service (session 0) this is a live check that a jail rule really took effect:
+    /// session 0 never matches the jail, so a confined device must become unopenable here while
+    /// staying open inside its seat.
+    ///
+    /// ⚠️ <b>Which failure it was, is the whole answer.</b> A jail refuses the open with
+    /// <c>ERROR_ACCESS_DENIED</c> (5) and nothing else. An absent device — or a malformed path —
+    /// fails with <c>ERROR_FILE_NOT_FOUND</c> (2). Reading only "did the handle come back invalid"
+    /// turns both into "the jail is holding", so <b>a rule that matches nothing verifies as a rule
+    /// being enforced</b>: the exact silent success this probe exists to prevent, sitting inside
+    /// the probe.
+    ///
+    /// That distinction is also a cheap version of the "open an ordinary file first" control: a
+    /// probe that has broken and can open nothing returns 2, not 5, so it cannot fake a confined
+    /// device. It is the weaker of the two checks — it only catches breakage in the path rather
+    /// than in the process — but it costs one integer.
+    ///
+    /// Note what a <see cref="JailProbe.Confined"/> does and does not prove. It says session 0 is
+    /// being refused, which is what a working rule looks like from here — it does NOT prove the
+    /// seat can still see the pad. A plain global hide (or a rule whose suffix was stripped)
+    /// produces the same refusal.
+    /// </summary>
+    public static JailProbeResult Probe(string symbolicLink)
+    {
+        // An empty path is not a refusal. Returning "confined" for one would report a jail on a
+        // device that was never named.
+        if (string.IsNullOrWhiteSpace(symbolicLink))
+            return new JailProbeResult(JailProbe.Unreachable, ERROR_FILE_NOT_FOUND);
 
         using var handle = CreateFileW(
             symbolicLink,
@@ -157,7 +201,15 @@ public static class HidHideSessionJail
             0,
             IntPtr.Zero);
 
-        return !handle.IsInvalid;
+        // Immediately, and before anything else runs: the next managed call is free to overwrite
+        // the thread's last error.
+        var error = Marshal.GetLastWin32Error();
+
+        if (!handle.IsInvalid) return new JailProbeResult(JailProbe.Open, 0);
+
+        return new JailProbeResult(
+            error == ERROR_ACCESS_DENIED ? JailProbe.Confined : JailProbe.Unreachable,
+            error);
     }
 
     // ── interop ──────────────────────────────────────────────────────
@@ -166,6 +218,8 @@ public static class HidHideSessionJail
     private const uint FILE_SHARE_READ = 1;
     private const uint FILE_SHARE_WRITE = 2;
     private const uint OPEN_EXISTING = 3;
+    internal const int ERROR_FILE_NOT_FOUND = 2;
+    internal const int ERROR_ACCESS_DENIED = 5;
 
     [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode)]
     private static extern uint CM_Locate_DevNodeW(out uint pdnDevInst, string pDeviceID, uint ulFlags);

--- a/src/MultiSeat.Tests/Input/HidHideSessionJailTests.cs
+++ b/src/MultiSeat.Tests/Input/HidHideSessionJailTests.cs
@@ -114,6 +114,72 @@ public class HidHideSessionJailTests
     // need a test of its own. This feature writes into a kernel-side, persistent blacklist and can
     // take a controller away from whoever is holding it, so "off unless asked for" has to be true
     // in both places at once.
+    // ── The session-0 probe ──────────────────────────────────────────
+    //
+    // These exist because the probe had the failure it was built to prevent, inside itself. It
+    // read only "did the handle come back invalid", so a rule matching NOTHING verified as a rule
+    // being enforced.
+    //
+    // A jail refuses an open with ERROR_ACCESS_DENIED (5) and nothing else. An absent device, or
+    // a malformed path, fails with ERROR_FILE_NOT_FOUND (2). Measured 2026-08-21 with a positive
+    // control, so a probe that can open nothing could not fake the result:
+    //
+    //   a real file (control that the P/Invoke works at all)          opens
+    //   a well-formed HID path for a device that is NOT present       fails, err=2
+    //   a malformed path                                              fails, err=2
+    //
+    // The bottom two rows used to report a working jail. There is deliberately no test asserting
+    // Confined: producing a 5 needs a live rule on a real device, which is exactly what cannot be
+    // arranged on a build agent — and is why the code reads the error rather than the boolean.
+
+    [Fact]
+    public void ARealFileOpens_SoTheProbeItselfWorks()
+    {
+        // The control. Without it every row below is satisfied by a probe that opens nothing at
+        // all, which is indistinguishable from a jail that is working perfectly.
+        var probe = HidHideSessionJail.Probe(typeof(HidHideSessionJailTests).Assembly.Location);
+
+        Assert.Equal(HidHideSessionJail.JailProbe.Open, probe.Verdict);
+        Assert.Equal(0, probe.Error);
+    }
+
+    [Fact]
+    public void AWellFormedPathToAnAbsentDeviceIsNotVerified()
+    {
+        // Shaped exactly like a real HID node's device path, naming a device that is not there.
+        // This is the case that used to report "the jail is holding".
+        const string absent =
+            @"\\?\hid#vid_045e&pid_028e&ig_00#3&00000000&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}";
+
+        var probe = HidHideSessionJail.Probe(absent);
+
+        Assert.Equal(HidHideSessionJail.JailProbe.Unreachable, probe.Verdict);
+        Assert.NotEqual(HidHideSessionJail.ERROR_ACCESS_DENIED, probe.Error);
+    }
+
+    [Theory]
+    [InlineData(@"not a device path at all")]
+    [InlineData(@"\\?\hid#")]
+    [InlineData(@"USB\VID_045E&PID_028E\01")]   // an instance path, not a device path - a real mistake
+    public void AMalformedPathIsNotVerifiedEither(string path)
+    {
+        var probe = HidHideSessionJail.Probe(path);
+
+        Assert.Equal(HidHideSessionJail.JailProbe.Unreachable, probe.Verdict);
+        Assert.NotEqual(HidHideSessionJail.ERROR_ACCESS_DENIED, probe.Error);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void AnEmptyPathIsNotARefusal(string? path)
+    {
+        // A device that was never named cannot have been refused. Returning "confined" here would
+        // report a jail on nothing at all.
+        Assert.Equal(HidHideSessionJail.JailProbe.Unreachable, HidHideSessionJail.Probe(path!).Verdict);
+    }
+
     [Fact]
     public void TheShippedDefaultsMatchTheCompiledOnesAndAreOff()
     {


### PR DESCRIPTION
Follow-up to #19. This is your own `err=5, not err=2` note, applied to the code that carries it.

## The defect

`HidHideSessionJail.CanOpen` returns `!handle.IsInvalid`, so **every** way of failing to open a
device reads as "the jail is holding":

```csharp
return !handle.IsInvalid;
```

A jail refuses an open with `ERROR_ACCESS_DENIED` (5) and nothing else. An absent device — or a
malformed path — fails with `ERROR_FILE_NOT_FOUND` (2). So a rule that matches **nothing** verifies
as a rule being enforced.

That is the exact silent success this probe exists to prevent, sitting inside the probe. Which is a
shape I have no standing to be smug about: `SessionJailVerifier.Verify` on my side had the identical
line, and your note is what made me look. I wrote nine sections warning other people about this
shape and then wrote it. Being the author of the argument turns out to be no protection.

The path that matters in practice is `EnablePadRulePreWrite`: a pre-written rule names a device that
is *deliberately* not there yet. Probe it and you get a 2, and the log says the jail is verified.

## What changes

`CanOpen(string) : bool` becomes `Probe(string) : JailProbeResult`, three verdicts instead of two:

| verdict | means |
|---|---|
| `Open` | it opened — whatever is on paper, the confinement is not in effect |
| `Confined` | `ERROR_ACCESS_DENIED` — what a live jail looks like from session 0 |
| `Unreachable` | anything else — **nothing was proved either way** |

`VerifyJail` logs `Unreachable` as a warning naming the Win32 code, instead of as a verified jail.
`--hidhide` prints the verdict and the code rather than a boolean.

An empty path returns `Unreachable` too: a device that was never named cannot have been refused, and
the old code returned `false` there.

I removed the boolean rather than keeping it alongside. Keeping it keeps the trap — there is no
correct way to collapse three answers into two here — and both call sites are in this repo. Happy to
restore it as a wrapper if you would rather not lose the name.

## A second-order thing your write-up gave me

Distinguishing 5 from 2 is a cheap version of your "open an ordinary file first" control. Yours
guards against a probe that cannot open *anything*; reading the code guards against the same failure
from the other end, because a broken probe returns 2, not 5.

Yours is still the stronger check — mine only catches breakage in the path rather than in the
process — so it is not a replacement. Your control is in the tests below, as the positive control.

## Tests

Measured on the reference host 2026-08-21, with the control so a probe that can open nothing could
not fake the result:

| probe | result |
|---|---|
| a real file (control that the P/Invoke works at all) | **opens** |
| a well-formed HID device path for a device that is **not present** | fails `err=2` |
| a malformed path | fails `err=2` |

Both of the bottom rows used to return "the jail is holding".

There is deliberately **no test asserting `Confined`**. Producing a 5 needs a live rule on a real
device, which is exactly what cannot be arranged on a build agent — and is the reason the code reads
the error rather than the boolean. That is written into the test file so nobody later "completes"
the matrix with a mock that proves nothing.

## Verification

Your CI, run on my fork before opening this: **Build + test** and **Script lint (PowerShell 5.1 + 7)**
both green on `windows-latest`.

I have not run this against a live jail on my host yet — my tree has diverged from yours enough that
a clean measurement needs the rebase I owe you first. What is verified here is the error-code
distinction and that the three rows above behave as measured.

---

Two notes on process, since this is the first PR I have sent you:

- Say the word if you would rather keep taking things through issues and reimplementing. That has
  worked well and I am not attached to the code being mine — it is the measurement that matters.
- The remaining pieces you asked to compare (the attribution code, and the retry policy around
  `0x0005`) are next, once I have rebased onto your `HidHideConfigurator` rather than offering you
  mine.
