### PR TITLE
Four fixes required to integrate MultiSeat with MoonlightWeb

### DIFF
--- a/src/MultiSeat.Service/Configuration/MultiSeatOptions.cs
+++ b/src/MultiSeat.Service/Configuration/MultiSeatOptions.cs
@@ -17,6 +17,16 @@ public sealed class MultiSeatOptions
     // Apollo default is 1; we raise it because the NVENC hardware handles P4 at full framerate.
     public int NvencPreset { get; set; } = 4;
 
+    /// <summary>
+    /// Apollo encoder used for every seat. Left at "nvenc" nothing changes:
+    /// Apollo falls back on its own where NVENC is absent. Set it explicitly on
+    /// hosts where that fallback misbehaves — on AMD the AMF probe runs at
+    /// startup against the RDP surface a seat provides, and can hang there
+    /// before Apollo ever opens its ports. Apollo's own values: nvenc,
+    /// quicksync, amdvce, software.
+    /// </summary>
+    public string Encoder { get; set; } = "nvenc";
+
     // ── API ──────────────────────────────────────────────────────────
     public int ApiPort { get; set; } = Shared.Constants.DefaultApiPort;
     public string ApiKey { get; set; } = string.Empty;  // set in appsettings or env

--- a/src/MultiSeat.Service/Configuration/MultiSeatOptions.cs
+++ b/src/MultiSeat.Service/Configuration/MultiSeatOptions.cs
@@ -27,6 +27,14 @@ public sealed class MultiSeatOptions
     /// </summary>
     public string Encoder { get; set; } = "nvenc";
 
+    /// <summary>
+    /// Apollo's own log level for every seat. "info" is what a seat needs day
+    /// to day; "debug" is the only way to see why a seat's Apollo refuses a
+    /// pairing or a client, since its log is the sole window into a session
+    /// nobody can watch. Apollo's values: verbose, debug, info, warning, error.
+    /// </summary>
+    public string ApolloLogLevel { get; set; } = "info";
+
     // ── API ──────────────────────────────────────────────────────────
     public int ApiPort { get; set; } = Shared.Constants.DefaultApiPort;
     public string ApiKey { get; set; } = string.Empty;  // set in appsettings or env

--- a/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
+++ b/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Security.AccessControl;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -72,7 +73,7 @@ public sealed class ApolloConfigBuilder
         // generated sunshine.conf so Apollo uses that path instead of the shared exe-dir default.
         // Only create if absent — pairings (stored in sunshine_state) survive re-provisioning.
         EnsureSeatConfigDir(seatDir);
-        EnsureSeatStateFile(seatDir);
+        EnsureSeatStateFile(seatDir, seat.AccountName);
         EnsureSeatAppsJson(seatDir);
 
         var sb = new StringBuilder(2048);
@@ -520,10 +521,15 @@ public sealed class ApolloConfigBuilder
     /// Apollo is pointed here via file_state = {seatDir}/config/sunshine_state.json in the config.
     /// Only creates the file if absent — preserves pairings on re-provision.
     /// </summary>
-    private void EnsureSeatStateFile(string seatDir)
+    private void EnsureSeatStateFile(string seatDir, string accountName)
     {
         var statePath = Path.Combine(seatDir, "config", "sunshine_state.json");
-        if (File.Exists(statePath)) return;
+        if (File.Exists(statePath))
+        {
+            // Seats provisioned before this ran still carry the read-only ACL.
+            GrantSeatWrite(statePath, accountName);
+            return;
+        }
 
         // UUID format matches what Apollo writes: uppercase 8-4-4-4-12
         var uuid = Guid.NewGuid().ToString("D").ToUpperInvariant();
@@ -537,7 +543,37 @@ public sealed class ApolloConfigBuilder
             """;
 
         File.WriteAllText(statePath, json, Encoding.UTF8);
+        GrantSeatWrite(statePath, accountName);
         _logger.LogInformation("Created per-seat state file with UUID {Uuid}: {Path}", uuid, statePath);
+    }
+
+    /// <summary>
+    /// Give the seat account write access to a file the service created.
+    ///
+    /// Files written here inherit ProgramData's ACL, where Users get read and
+    /// execute but not write. Apollo runs as the seat account and rewrites the
+    /// state file every time it pairs a client — add_authorized_client() calls
+    /// save_state() then load_state(). The write fails silently, the reload puts
+    /// the old contents back, and the client that just paired is gone. The seat
+    /// pairs successfully and then refuses that client's certificate on every
+    /// call after, which is a hard failure to trace from either end.
+    /// </summary>
+    private void GrantSeatWrite(string path, string accountName)
+    {
+        try
+        {
+            var info = new FileInfo(path);
+            var acl = info.GetAccessControl();
+            acl.AddAccessRule(new FileSystemAccessRule(accountName, FileSystemRights.Modify, AccessControlType.Allow));
+            info.SetAccessControl(acl);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Could not grant {Account} write access to {Path} — Apollo will not be able to remember the clients this seat pairs",
+                accountName, path);
+        }
     }
 
     /// <summary>

--- a/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
+++ b/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
@@ -312,7 +312,8 @@ public sealed class ApolloConfigBuilder
 
         // ── Logging ───────────────────────────────────────────────────
         sb.AppendLine("# Logging");
-        sb.AppendLine("min_log_level = info");
+        var logLevel = string.IsNullOrWhiteSpace(_options.ApolloLogLevel) ? "info" : _options.ApolloLogLevel.Trim();
+        sb.AppendLine($"min_log_level = {logLevel}");
         sb.AppendLine($"log_path = {logPath}");
         sb.AppendLine();
 

--- a/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
+++ b/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
@@ -64,6 +64,7 @@ public sealed class ApolloConfigBuilder
         // All seats share one credentials file so web UI login persists across re-provisioning.
         // The file is created by MultiSeat on first run (from Apollo's default config) and survives seat teardown.
         var credPath = Path.Combine(configDir, "shared_credentials.json").Replace('\\', '/');
+        var tlsDir = Path.Combine(seatDir, "config", "credentials").Replace('\\', '/');
         EnsureSharedCredentials(configDir);
         // platf::appdata() on Windows resolves to {exe_dir}/config/ — not the working directory.
         // To isolate each seat's state file (and thus its UUID), we seed sunshine_state.json in
@@ -278,6 +279,13 @@ public sealed class ApolloConfigBuilder
         sb.AppendLine("# Security");
         sb.AppendLine($"file_state = {statePath}");
         sb.AppendLine($"credentials_file = {credPath}");
+        // The same reasoning covers the TLS material. Left at its default Apollo
+        // looks for cakey.pem under {exe_dir}/config/credentials/, inside Program
+        // Files — which a seat account cannot write, so it cannot even generate
+        // one. It dies on "HTTP interface failed to initialize" and never opens a
+        // port. The per-seat credentials/ dir is already created for this.
+        sb.AppendLine($"pkey = {tlsDir}/cakey.pem");
+        sb.AppendLine($"cert = {tlsDir}/cacert.pem");
         // Each seat has independent pairing — Moonlight pairs per-seat
         sb.AppendLine("origin_web_ui_allowed = lan");
         sb.AppendLine();

--- a/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
+++ b/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
@@ -162,10 +162,16 @@ public sealed class ApolloConfigBuilder
         sb.AppendLine();
 
         // ── Encoder ───────────────────────────────────────────────────
-        // Prefer NVENC for hardware-accelerated low-latency encoding.
-        // Apollo will fall back to AMF → software if NVENC is unavailable.
-        sb.AppendLine("# Encoder — NVENC for hardware-accelerated low-latency encoding");
-        sb.AppendLine("encoder = nvenc");
+        // NVENC by default, for hardware-accelerated low-latency encoding, and
+        // Apollo falls back on its own where it is absent. That fallback is not
+        // safe everywhere: on AMD it lands on AMF, whose startup probe runs
+        // against the RDP surface a seat provides — 1000Hz refresh, no real
+        // display — and hangs there. Apollo then never reaches the point where
+        // it opens its HTTP servers, so the seat reports Ready with no port
+        // listening. MultiSeat:Encoder lets such a host say what to use.
+        var encoder = string.IsNullOrWhiteSpace(_options.Encoder) ? "nvenc" : _options.Encoder.Trim();
+        sb.AppendLine($"# Encoder — {encoder} (MultiSeat:Encoder)");
+        sb.AppendLine($"encoder = {encoder}");
         sb.AppendLine();
 
         // ── NVENC tuning ──────────────────────────────────────────────


### PR DESCRIPTION
## Why this PR

[MoonlightWeb](https://github.com/linckosz/moonlight-web) streams a host to a plain browser. It
now talks to MultiSeat directly: it asks the service for a seat, pairs itself with that seat's
Apollo — submitting the pairing PIN through the seat's own web UI with the seat-admin
credentials, so nobody has to type it on the host — and streams it.

Making that work end to end turned up four problems. Three of them are not specific to
MoonlightWeb: they stop a seat from starting or from remembering a client, whichever Moonlight is
on the other end. The fourth is a convenience for anyone who has to debug a seat.

**Nothing changes for an existing install.** Every new setting keeps today's value when left
unset, and the permission fix only adds a right that was missing.

Bench: UM790Pro, Windows 11 Pro build 26200, RDPWrap, tested with a Radeon 780M and then with a
GTX 1050 in the same machine.

---

## 1. On an AMD host, a seat never starts

`feat(seats): let a host choose the Apollo encoder, so an AMD seat can start`

**What we saw.** The service reports the seat `Ready`. Nothing listens on any of its ports.
Apollo is running and burning a full CPU core. Its log stops at `Creating encoder [h264_amf]` and
never prints another line. No error, anywhere.

**Why.** The generated `sunshine.conf` always says `encoder = nvenc`, and counts on Apollo's own
fallback when NVENC is absent. On an AMD box that fallback is AMF. Apollo probes AMF at startup,
and the probe runs against the only screen a seat has — the RDP desktop, which reports a 1000 Hz
refresh rate — and never finishes. Apollo starts its HTTP servers *after* that probe, so it never
opens a port. The process is alive, which is exactly why MultiSeat still calls the seat `Ready`.

**The fix.** A new setting, `MultiSeat:Encoder`. Left unset it stays `nvenc`, so an NVIDIA host
behaves as it does today. An AMD host sets `amdvce` or `software` and the seat comes up.

**Changed.** `MultiSeatOptions` — new `Encoder` property. `ApolloConfigBuilder.BuildConfig` —
writes that value instead of the hard-coded `encoder = nvenc` line.

**Confirmed AMD-only.** We fitted a GTX 1050 in the same machine, left the setting at its default,
and the seat came up on `h264_nvenc`. The current default is right for NVIDIA; it just has no
escape hatch.

---

## 2. A seat cannot create the TLS key it needs, so Apollo dies at startup

`fix(seats): a seat's TLS material lands in Program Files, where it cannot write`

**What we saw.** With the encoder settled, Apollo still exited immediately:

```
Couldn't open [C:\Program Files\ApolloVibe\config\credentials/cakey.pem]
Fatal: HTTP interface failed to initialize
```

Still no port open, and the seat still reported `Ready`.

**Why.** Apollo resolves `pkey` and `cert` against its own install directory, under Program Files.
A seat runs as an ordinary Windows account, which cannot write there — so it can neither read the
key nor generate the one it is missing.

**The fix.** Point `pkey` and `cert` at the seat's own `config/credentials/` directory, which
MultiSeat already creates. The config builder already makes this exact argument for `file_state`
and `credentials_file`, with a comment explaining that Apollo resolves relative paths against a
directory shared by all instances. The TLS material had simply been missed.

**Changed.** `ApolloConfigBuilder.BuildConfig` — a `tlsDir` path, and two lines in the Security
block next to the existing `file_state` / `credentials_file` ones.

---

## 3. A seat forgets every client it pairs

`fix(seats): a seat cannot write its own state file, so every pairing it makes is lost`

This is the one that matters most, and the one that is hardest to see.

**What we saw.** Pairing looks perfect. The client walks all five pairing stages, the seat
confirms the pairing, the web UI lists the client. Then the very next request from that same
client is refused, as if it had never paired. Nothing is logged as an error at either end. This
cost us a full day before we stopped believing the pairing code.

**Why.** `EnsureSeatStateFile` creates `sunshine_state.json` while running as the service, so the
file inherits the ProgramData permissions: `BUILTIN\Users` may read and execute, but not write.
Apollo runs as the *seat's* account, and it rewrites that file on every pairing —
`add_authorized_client()` appends the client, then calls `save_state()` and `load_state()`. The
save fails silently, the reload puts the old contents back, and the client that just paired is
gone from `named_certs`.

The giveaway on our bench: the state file's timestamp was still the day the seat was provisioned,
after dozens of pairings.

**The fix.** Grant the seat's own account Modify on that one file — when it is created, and also
on seats that already have one, since those still carry the read-only inheritance. With it, the
last pairing stage flips from `401` to success, and `named_certs` finally keeps what it is given.

This follows what `SharedLibraryProvisioner` already does for the shared game library, where the
service grants `Users` Modify on directories the seats must write.

**Changed.** `ApolloConfigBuilder.EnsureSeatStateFile` — now takes the account name and grants on
both paths (new file and pre-existing file). New private `ApolloConfigBuilder.GrantSeatWrite` —
adds the rule, and warns rather than throwing if it cannot.

**One caveat, stated honestly.** We proved this on our bench and it was deterministic there:
granting Modify is what flipped pairing from broken to working. Whether every install inherits the
same read-only ACL, we cannot say — it depends on what the ProgramData tree ends up with. The fix
is cheap either way and is a no-op where the right is already present.

---

## 4. A seat's Apollo log level cannot be raised

`feat(seats): let a host raise Apollo's log level`

**What we saw.** When a seat refuses a pairing or a client, its Apollo log is the only window into
a session nobody can watch — and at `info` it says nothing about either.

**Why.** `min_log_level` is written as `info` and cannot be changed. Editing the generated
`sunshine.conf` by hand works until the next provision overwrites it.

**The fix.** A new setting, `MultiSeat:ApolloLogLevel`. Left unset it stays `info`, so nothing
changes.

**Changed.** `MultiSeatOptions` — new `ApolloLogLevel` property. `ApolloConfigBuilder.BuildConfig`
— writes it instead of the fixed `min_log_level = info` line.

---

## How this was tested

On the bench above, a seat now provisions, pairs with no PIN typed by a human, serves its app
list, and streams. Two different devices land on two different seats and stay on them across
reconnects. `serverinfo` answers as `MultiSeat-<account>-<n>` with `48095`, `48100` and `48101`
listening.

The branch is rebased on current `master` and builds clean (`dotnet build -c Release`, 0 errors;
the single `CS1998` warning is pre-existing, in `SessionLauncher.cs`, untouched here).
