### PR TITLE
A seat can never recover from a lost Windows session

### DIFF
--- a/src/MultiSeat.Service/Api/SeatEndpoints.cs
+++ b/src/MultiSeat.Service/Api/SeatEndpoints.cs
@@ -209,8 +209,25 @@ public static class SeatEndpoints
                 // Pass the seat's geometry: if the session has to be recreated rather than
                 // reattached, it must come back at the seat's own size, not inherit the
                 // console desktop's.
-                await sessionLauncher.LaunchSessionAsync(
+                //
+                // And keep the id it answers with. A recreated session is a NEW session,
+                // and everything that acts on this seat afterwards reads SessionId:
+                // ProcessInjector, the health check, display isolation. Dropped, they all
+                // keep aiming at the session that just went away — apollo/start fails with
+                // 500 and the seat can never come back.
+                seat.SessionId = await sessionLauncher.LaunchSessionAsync(
                     seat.AccountName, ct, RdpGeometry.ForClient(seat.Width, seat.Height));
+
+                // The health check parks a seat in Error when its session dies, and nothing
+                // ever takes it out again. Leave it there and the checks that would restart
+                // Apollo are skipped, so the seat stays broken although it now has a live
+                // session. Hand it back to the health check in the state it is actually in.
+                if (seat.Status == SeatStatus.Error)
+                {
+                    seat.Status = SeatStatus.Ready;
+                    seat.ErrorMessage = null;
+                }
+
                 return Results.Ok(new { sessionId = seat.SessionId, message = "Session reconnected" });
             });
 

--- a/src/MultiSeat.Service/Monitoring/SessionHealthCheck.cs
+++ b/src/MultiSeat.Service/Monitoring/SessionHealthCheck.cs
@@ -117,7 +117,10 @@ public sealed class SessionHealthCheck
                 // Pass the geometry: if the stale session has to be logged off and recreated,
                 // the replacement must come back at the seat's own size rather than inheriting
                 // the console desktop's.
-                await _sessionLauncher.LaunchSessionAsync(
+                //
+                // Keep the id it answers with: that path returns a NEW session, and the
+                // Apollo restart and display isolation just below both act on SessionId.
+                seat.SessionId = await _sessionLauncher.LaunchSessionAsync(
                     seat.AccountName, ct, RdpGeometry.ForClient(seat.Width, seat.Height));
 
                 // Give the display pipeline a moment to reinitialize after the session


### PR DESCRIPTION
## The symptom

A seat loses its Windows session — after a reboot is the easy way to see it — and goes to `Error`
with "Windows session terminated unexpectedly". `POST /api/seats/{id}/session-reconnect` answers
`200 {"message":"Session reconnected"}` and a new RDP session really is created, visible in
`qwinsta`. The seat stays in `Error` anyway, for good, and `apollo/start` answers 500 with the log
saying it launched "in session 2" while the live session is 4. The only way out is teardown and
re-provision.

Three separate things have to be true for a seat to come back, and none of them was.

## 1. The new session's id is thrown away

`LaunchSessionAsync` returns the id of the live session, and that id is a **new** one whenever the
session had to be recreated rather than reattached — which is the case this endpoint exists for.
The endpoint awaited it and discarded the answer, then reported the seat's old `SessionId` back to
the caller as if nothing had moved.

Everything downstream reads `SessionId`: `ProcessInjector` launches into it, the health check tests
it for liveness, display isolation applies to it. All three keep aiming at the session that just
went away.

**Changed** — `SeatEndpoints.cs`, the `session-reconnect` handler: `seat.SessionId = await
sessionLauncher.LaunchSessionAsync(...)`.

## 2. The health check drops it the same way

`SessionHealthCheck.CheckSeatAsync` has its own reconnect path, for a session that went
`Disconnected` because the machine slept. It calls the same method and discards the same answer —
in the branch whose own comment says the stale session may be logged off and recreated. The Apollo
restart and the display-isolation call immediately below it then act on the old id.

**Changed** — `SessionHealthCheck.cs`: same one-line assignment.

## 3. Nothing ever takes a seat out of `Error`

This is what made the failure permanent rather than merely wrong.

The health check parks a seat in `Error` when its session dies, and there is no path back out. That
matters beyond the label: the check that restarts a dead Apollo only runs for a seat in `Ready` or
`Streaming`. So even with the id fixed, a seat with a perfectly healthy new session would sit in
`Error` with no Apollo, and nothing would ever start one.

`session-reconnect` is the explicit "recover this seat" action, so it is the right place to hand the
seat back: if it was in `Error`, put it back to `Ready` and clear the message, and let the health
check take it from there — which it does, restarting Apollo on its next tick.

**Changed** — `SeatEndpoints.cs`, same handler.

## How this was tested

On a UM790Pro (Windows 11 Pro build 26200, RDPWrap), by logging a seat's Windows session off with
`logoff <id>` and waiting for the health check to notice. Same seat, same steps, before and after:

| | before | after |
|---|---|---|
| Session Windows actually created | 6 | 12 |
| What `session-reconnect` answered | `{"sessionId":5}` | `{"sessionId":12}` |
| Seat afterwards | `Error`, session 5, permanently | `Ready`, session 12 |
| Apollo | dead, never restarted | restarted on the next health-check tick |
| `serverinfo` on the seat's port | nothing | answers `MultiSeat-<account>-<n>` |

Stable across 80 s of polling afterwards, and the other seat on the machine was unaffected
throughout.

`dotnet build -c Release`: 0 errors (the single `CS1998` in `SessionLauncher.cs` is pre-existing and
untouched). `dotnet test`: 245 passed, 17 skipped, 2 failed — both failures are in
`RdpCredentialStoreTests` (`CredWrite reported failure`) and reproduce identically with these
changes reverted; they are the test host having no writable Windows credential store, not this
change.

## Note

This is independent of #21 — different files, no overlap, and it is branched from `master` rather
than from that branch. Either can go in first.
