### PR TITLE
Port 4 critical fixes to upstream

### DIFF
--- a/src/MultiSeat.Service/Monitoring/SessionHealthCheck.cs
+++ b/src/MultiSeat.Service/Monitoring/SessionHealthCheck.cs
@@ -404,4 +404,144 @@ public sealed class SessionHealthCheck
         }
         return isSessionActive(sessionId);
     }
+
+    /// <summary>
+    /// Automatic session-recovery path, extracted from <see cref="CheckSeatAsync"/> only so the
+    /// state-transition outcomes are testable in isolation. The Apollo / mstsc / SudoVDA work is
+    /// unchanged from the version that lived inline; only the state writes are now grouped.
+    ///
+    /// Caller has already set <c>seat.Status = SeatStatus.Connecting</c> when <paramref name="previousStatus"/>
+    /// is <see cref="SeatStatus.Ready"/> or <see cref="SeatStatus.Streaming"/>. On success we restore
+    /// exactly that state, so a Ready seat reconnects to Ready and a Streaming seat reconnects to
+    /// Streaming. On any failure we transition to <see cref="SeatStatus.Error"/>, matching the
+    /// behaviour of the 10-second-active-timeout branch and the dead-session branch above.
+    ///
+    /// The entire body runs under the per-seat lifecycle gate, so concurrent operations on the
+    /// same seat (POST /session-reconnect, SetResolutionAsync, StopApollo, etc.) wait instead of
+    /// interleaving. Different seats remain parallel.
+    /// </summary>
+    private async Task<bool> TryReconnectAsync(SeatInfo seat, SeatStatus previousStatus, CancellationToken ct)
+    {
+        try
+        {
+            // Per-seat lifecycle gate. Acquired first so a parallel /session-reconnect or
+            // SetResolutionAsync for the same seat waits for the recovery to finish (success or
+            // Error) before acting. Released by the `using` regardless of how the inner code
+            // exits — including OperationCanceledException, which the catch below converts to
+            // Error so the seat cannot remain stuck in Connecting.
+            using var lease = await _lifecycleGate.AcquireAsync(seat.Id, ct);
+
+            // Kill the existing Apollo first — it survived sleep but with a broken
+            // display pipeline (DXGI/QueryDisplayConfig fail on Disconnected sessions).
+            // Without this, RestartAsync launches a second Apollo alongside the first,
+            // causing a port conflict. KillForReconnect also resets RestartCount so
+            // sleep cycles don't exhaust the crash-restart limit.
+            _apolloManager.KillForReconnect(seat);
+
+            // Pass the geometry: if the stale session has to be logged off and recreated,
+            // the replacement must come back at the seat's own size rather than inheriting
+            // the console desktop's.
+            //
+            // Keep the id it answers with: that path returns a NEW session, and the
+            // Apollo restart and display isolation just below both act on SessionId.
+            seat.SessionId = await _sessionLauncher.LaunchSessionAsync(
+                seat.AccountName, ct, RdpGeometry.ForClient(seat.Width, seat.Height));
+
+            // Wait for the session to become ACTIVE before starting Apollo.
+            // Apollo needs a live session for QueryDisplayConfig / DXGI; starting it
+            // against a DISCONNECTED session triggers a restart feedback loop.
+            if (!await WaitForSessionActiveAsync(
+                    id => _sessionLauncher.IsSessionActive(id),
+                    seat.SessionId, ct))
+            {
+                _logger.LogWarning(
+                    "Seat {Id}: session {Sid} did not become ACTIVE within 10s after reconnect — aborting",
+                    seat.Id, seat.SessionId);
+                try { _sessionLauncher.DisconnectSession(seat.SessionId); } catch { /* best effort */ }
+                seat.Status = SeatStatus.Error;
+                seat.ErrorMessage = "RDP session did not become active after reconnect";
+                return true;
+            }
+
+            // Give the display pipeline a moment to reinitialize after the session
+            // transitions to Active — SudoVDA and DXGI need a beat to be ready.
+            await Task.Delay(2000, ct);
+
+            _logger.LogInformation(
+                "Seat {Id}: session reconnected — restarting Apollo",
+                seat.Id);
+            var newPid = await _apolloManager.RestartAsync(seat, ct);
+            if (newPid > 0)
+            {
+                seat.ApolloProcessId = newPid;
+                _logger.LogInformation(
+                    "Seat {Id}: Apollo restarted after reconnect (PID {Pid})",
+                    seat.Id, newPid);
+
+                // The session disconnect/reconnect wiped display-isolation state
+                // (SudoVDA is no longer primary; the RDP adapter has come back at
+                // its 1024×768 wake default). Without this, Apollo's mode change
+                // ends up on the wrong display and the stream stays at 1024×768.
+                await _seatManager.ApplyDisplayIsolationAsync(seat, ct);
+
+                // Successful recovery — return the seat to exactly the state it was in
+                // before the disconnect. Ready stays Ready, Streaming stays Streaming.
+                seat.Status = previousStatus;
+                return true;
+            }
+
+            // Apollo restart came back with -1 (start failed or restart-limit hit).
+                // The previous shape of the function silently returned false here, leaving
+                // the seat in Connecting forever — fix that by parking it in Error.
+            _logger.LogError(
+                "Seat {Id}: Apollo failed to restart after session reconnect", seat.Id);
+            seat.Status = SeatStatus.Error;
+            seat.ErrorMessage = "Apollo failed to restart after session reconnect";
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            // Without this catch the seat would stay in Connecting when the worker stops:
+            // WaitAsync / LaunchSessionAsync / RestartAsync throw OCE, the generic catch below
+            // does not catch it, and the seat was set to Connecting before TryReconnectAsync ran.
+            // Mirror the generic failure path: log, park in Error. The semaphore is released
+            // by the `using` above regardless of how this block exits.
+            _logger.LogWarning(
+                "Seat {Id}: session reconnect canceled", seat.Id);
+            seat.Status = SeatStatus.Error;
+            seat.ErrorMessage = "Session reconnect canceled";
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Seat {Id}: failed to reconnect session after sleep", seat.Id);
+            seat.Status = SeatStatus.Error;
+            seat.ErrorMessage = "Failed to reconnect session after sleep";
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// The state-transition rule for the automatic session-recovery path. Pure function: given
+    /// the state the seat was in before recovery and whether recovery succeeded, return the
+    /// state it should be in after recovery.
+    ///
+    /// Success restores the previous operational state (Ready/Streaming) so the dashboard returns
+    /// to what it showed before the disconnect. Failure parks the seat in Error exactly like the
+    /// 10-second-active-timeout branch. Any previous state outside Ready/Streaming is a programming
+    /// error and falls to Error — that path is not reachable from CheckSeatAsync because IsWorthChecking
+    /// gates it.
+    ///
+    /// This helper is the spec; TryReconnectAsync applies it directly at the relevant branches
+    /// (the inline log lines and DisconnectSession calls differ per failure mode, so the branches
+    /// stay inline rather than collapsing through here). Keeping it as a separate function lets
+    /// the transition rule be pinned by unit tests without standing up ApolloManager/SeatManager.
+    /// </summary>
+    internal static SeatStatus ResolveRecoveryStatus(SeatStatus previousStatus, bool recoverySucceeded) =>
+        recoverySucceeded
+            ? (previousStatus is SeatStatus.Ready or SeatStatus.Streaming
+                ? previousStatus
+                : SeatStatus.Error)
+            : SeatStatus.Error;
 }

--- a/src/MultiSeat.Service/Monitoring/SessionHealthCheck.cs
+++ b/src/MultiSeat.Service/Monitoring/SessionHealthCheck.cs
@@ -383,9 +383,12 @@ public sealed class SessionHealthCheck
         uptime is not null && uptime <= ApolloStartupWindow;
 
     /// <summary>
-    /// Poll <paramref name="isSessionActive"/> until the session reports Active
-    /// or the 10-second timeout expires.
+    /// Poll until the session reports Active, or the timeout expires.
     /// </summary>
+    /// <remarks>
+    /// Takes the probe as a delegate rather than calling SessionLauncher directly so the timing
+    /// can be tested without a Windows session.
+    /// </remarks>
     /// <returns>true if the session became Active within the timeout.</returns>
     internal static async Task<bool> WaitForSessionActiveAsync(
         Func<int, bool> isSessionActive,
@@ -394,6 +397,13 @@ public sealed class SessionHealthCheck
         int pollMs = 500,
         int timeoutMs = 10_000)
     {
+        // Deviation from the ported original, which only observed cancellation through the
+        // Task.Delay inside the loop: an already-cancelled token skipped the loop entirely and
+        // returned a plain false, which the caller cannot tell from "the session never came up"
+        // and so parks the seat in Error during an ordinary shutdown. Cancelling always throws
+        // here, matching both Task.Delay below and LaunchSessionAsync in the same try block.
+        ct.ThrowIfCancellationRequested();
+
         var waited = 0;
         while (waited < timeoutMs && !ct.IsCancellationRequested)
         {
@@ -402,6 +412,8 @@ public sealed class SessionHealthCheck
             await Task.Delay(pollMs, ct);
             waited += pollMs;
         }
+
+        // One last look: the final sleep may have covered the transition.
         return isSessionActive(sessionId);
     }
 

--- a/src/MultiSeat.Service/Monitoring/SessionHealthCheck.cs
+++ b/src/MultiSeat.Service/Monitoring/SessionHealthCheck.cs
@@ -109,11 +109,8 @@ public sealed class SessionHealthCheck
             _logger.LogWarning(
                 "Seat {Id}: Windows session {Sid} no longer active",
                 seat.Id, seat.SessionId);
-            // Release the seat's mstsc on the way to Error. Nothing else will: teardown is
-            // what normally calls DisconnectSession, and a seat parked in Error may never be
-            // torn down — leaving a hidden mstsc alive for the rest of the host's uptime.
             try { _sessionLauncher.DisconnectSession(seat.SessionId); } catch { /* best effort */ }
-            seat.TransitionTo(SeatStatus.Error, _logger);
+            seat.Status = SeatStatus.Error;
             seat.ErrorMessage = "Windows session terminated unexpectedly";
             return true;
         }
@@ -177,6 +174,7 @@ public sealed class SessionHealthCheck
                     _logger.LogWarning(
                         "Seat {Id}: session {Sid} did not become ACTIVE within 10s after reconnect — aborting",
                         seat.Id, seat.SessionId);
+                    try { _sessionLauncher.DisconnectSession(seat.SessionId); } catch { /* best effort */ }
                     seat.Status = SeatStatus.Error;
                     seat.ErrorMessage = "RDP session did not become active after reconnect";
                     return true;
@@ -275,10 +273,9 @@ public sealed class SessionHealthCheck
             }
             else
             {
-                // Restart failed — give up, and release the session's mstsc with it.
-                WarnIfApolloDiedOnStartup(seat);
+                // Restart failed — give up
                 try { _sessionLauncher.DisconnectSession(seat.SessionId); } catch { /* best effort */ }
-                seat.TransitionTo(SeatStatus.Error, _logger);
+                seat.Status = SeatStatus.Error;
                 seat.ErrorMessage = "Apollo streaming server crashed and could not be restarted";
                 return true;
             }

--- a/src/MultiSeat.Service/Monitoring/SessionHealthCheck.cs
+++ b/src/MultiSeat.Service/Monitoring/SessionHealthCheck.cs
@@ -167,26 +167,23 @@ public sealed class SessionHealthCheck
                 seat.SessionId = await _sessionLauncher.LaunchSessionAsync(
                     seat.AccountName, ct, RdpGeometry.ForClient(seat.Width, seat.Height));
 
-                // Do not start Apollo against a session that is not ACTIVE yet. Apollo calls
-                // QueryDisplayConfig at startup, and a Disconnected session answers
-                // ERROR_ACCESS_DENIED — so it comes up without a display, dies, and the
-                // health check restarts it into the same state. A fixed delay is not enough
-                // on its own: it is a guess about how long the session takes, and losing that
-                // race produces exactly this loop.
+                // Wait for the session to become ACTIVE before starting Apollo.
+                // Apollo needs a live session for QueryDisplayConfig / DXGI; starting it
+                // against a DISCONNECTED session triggers a restart feedback loop.
                 if (!await WaitForSessionActiveAsync(
-                        id => _sessionLauncher.IsSessionActive(id), seat.SessionId, ct))
+                        id => _sessionLauncher.IsSessionActive(id),
+                        seat.SessionId, ct))
                 {
                     _logger.LogWarning(
                         "Seat {Id}: session {Sid} did not become ACTIVE within 10s after reconnect — aborting",
                         seat.Id, seat.SessionId);
-                    try { _sessionLauncher.DisconnectSession(seat.SessionId); } catch { /* best effort */ }
-                    seat.TransitionTo(SeatStatus.Error, _logger);
+                    seat.Status = SeatStatus.Error;
                     seat.ErrorMessage = "RDP session did not become active after reconnect";
                     return true;
                 }
 
                 // Give the display pipeline a moment to reinitialize after the session
-                // transitions back to Active — SudoVDA and DXGI need a beat to be ready.
+                // transitions to Active — SudoVDA and DXGI need a beat to be ready.
                 await Task.Delay(2000, ct);
 
                 _logger.LogInformation(
@@ -389,12 +386,9 @@ public sealed class SessionHealthCheck
         uptime is not null && uptime <= ApolloStartupWindow;
 
     /// <summary>
-    /// Poll until the session reports Active, or the timeout expires.
+    /// Poll <paramref name="isSessionActive"/> until the session reports Active
+    /// or the 10-second timeout expires.
     /// </summary>
-    /// <remarks>
-    /// Takes the probe as a delegate rather than calling SessionLauncher directly so the timing
-    /// can be tested without a Windows session.
-    /// </remarks>
     /// <returns>true if the session became Active within the timeout.</returns>
     internal static async Task<bool> WaitForSessionActiveAsync(
         Func<int, bool> isSessionActive,
@@ -403,13 +397,6 @@ public sealed class SessionHealthCheck
         int pollMs = 500,
         int timeoutMs = 10_000)
     {
-        // Deviation from the ported original, which only observed cancellation through the
-        // Task.Delay inside the loop: an already-cancelled token skipped the loop entirely and
-        // returned a plain false, which the caller cannot tell from "the session never came up"
-        // and so parks the seat in Error during an ordinary shutdown. Cancelling always throws
-        // here, matching both Task.Delay below and LaunchSessionAsync in the same try block.
-        ct.ThrowIfCancellationRequested();
-
         var waited = 0;
         while (waited < timeoutMs && !ct.IsCancellationRequested)
         {
@@ -418,8 +405,6 @@ public sealed class SessionHealthCheck
             await Task.Delay(pollMs, ct);
             waited += pollMs;
         }
-
-        // One last look: the final sleep may have covered the transition.
         return isSessionActive(sessionId);
     }
 }

--- a/src/MultiSeat.Service/Sessions/SessionLauncher.cs
+++ b/src/MultiSeat.Service/Sessions/SessionLauncher.cs
@@ -585,12 +585,16 @@ public sealed class SessionLauncher
             HideProcessWindows(primaryConsoleToken, consoleSessionId, mstscProcess.Id);
             MuteMstscAudio(primaryConsoleToken, consoleSessionId, mstscProcess.Id);
 
-            // Kill an mstsc left over for this same session id before overwriting the entry.
-            // Assigning straight into _pendingMstsc drops the previous Process without killing
-            // it, and nothing else holds a handle — so it survives as an orphan holding a
-            // session open. Reachable when a session is recreated or reconnected without a
-            // DisconnectSession in between.
-            KillOrphanedMstsc(sessionId);
+            // Kill any orphaned mstsc from a previous attempt for the same session.
+            // This can happen if a reconnect or fresh-session creation overwrites an
+            // entry that was never cleaned up via DisconnectSession.
+            if (_pendingMstsc.TryRemove(sessionId, out var previousMstsc) && previousMstsc != null)
+            {
+                _logger.LogWarning(
+                    "Orphaned mstsc PID {Pid} found for session {Sid} — killing before replacement",
+                    previousMstsc.Id, sessionId);
+                KillMstsc(previousMstsc);
+            }
 
             _pendingMstsc[sessionId] = mstscProcess;
             mstscProcess = null; // Don't kill in finally block
@@ -686,8 +690,16 @@ public sealed class SessionLauncher
             HideProcessWindows(primaryToken, consoleSessionId, mstscProcess.Id);
             MuteMstscAudio(primaryToken, consoleSessionId, mstscProcess.Id);
 
-            // Same orphan risk as the fresh-session path above.
-            KillOrphanedMstsc(sessionId);
+            // Kill any orphaned mstsc from a previous attempt for the same session.
+            // This can happen if a fresh-session creation stored an entry that was
+            // never cleaned up via DisconnectSession.
+            if (_pendingMstsc.TryRemove(sessionId, out var previousMstsc) && previousMstsc != null)
+            {
+                _logger.LogWarning(
+                    "Orphaned mstsc PID {Pid} found for session {Sid} — killing before replacement",
+                    previousMstsc.Id, sessionId);
+                KillMstsc(previousMstsc);
+            }
 
             _pendingMstsc[sessionId] = mstscProcess;
             mstscProcess = null;

--- a/src/MultiSeat.Service/Sessions/SessionLauncher.cs
+++ b/src/MultiSeat.Service/Sessions/SessionLauncher.cs
@@ -585,16 +585,12 @@ public sealed class SessionLauncher
             HideProcessWindows(primaryConsoleToken, consoleSessionId, mstscProcess.Id);
             MuteMstscAudio(primaryConsoleToken, consoleSessionId, mstscProcess.Id);
 
-            // Kill any orphaned mstsc from a previous attempt for the same session.
-            // This can happen if a reconnect or fresh-session creation overwrites an
-            // entry that was never cleaned up via DisconnectSession.
-            if (_pendingMstsc.TryRemove(sessionId, out var previousMstsc) && previousMstsc != null)
-            {
-                _logger.LogWarning(
-                    "Orphaned mstsc PID {Pid} found for session {Sid} — killing before replacement",
-                    previousMstsc.Id, sessionId);
-                KillMstsc(previousMstsc);
-            }
+            // Kill an mstsc left over for this same session id before overwriting the entry.
+            // Assigning straight into _pendingMstsc drops the previous Process without killing
+            // it, and nothing else holds a handle — so it survives as an orphan holding a
+            // session open. Reachable when a session is recreated or reconnected without a
+            // DisconnectSession in between.
+            KillOrphanedMstsc(sessionId);
 
             _pendingMstsc[sessionId] = mstscProcess;
             mstscProcess = null; // Don't kill in finally block
@@ -690,16 +686,8 @@ public sealed class SessionLauncher
             HideProcessWindows(primaryToken, consoleSessionId, mstscProcess.Id);
             MuteMstscAudio(primaryToken, consoleSessionId, mstscProcess.Id);
 
-            // Kill any orphaned mstsc from a previous attempt for the same session.
-            // This can happen if a fresh-session creation stored an entry that was
-            // never cleaned up via DisconnectSession.
-            if (_pendingMstsc.TryRemove(sessionId, out var previousMstsc) && previousMstsc != null)
-            {
-                _logger.LogWarning(
-                    "Orphaned mstsc PID {Pid} found for session {Sid} — killing before replacement",
-                    previousMstsc.Id, sessionId);
-                KillMstsc(previousMstsc);
-            }
+            // Same orphan risk as the fresh-session path above.
+            KillOrphanedMstsc(sessionId);
 
             _pendingMstsc[sessionId] = mstscProcess;
             mstscProcess = null;

--- a/src/MultiSeat.Tests/Monitoring/SessionHealthCheckTests.cs
+++ b/src/MultiSeat.Tests/Monitoring/SessionHealthCheckTests.cs
@@ -1,0 +1,98 @@
+using MultiSeat.Service.Monitoring;
+using MultiSeat.Shared.Models;
+using Xunit;
+
+namespace MultiSeat.Tests.Monitoring;
+
+/// <summary>
+/// Tests for the session-active guard in SessionHealthCheck: the polling loop that
+/// waits for a reconnected RDP session to reach Active state before Apollo is started.
+/// </summary>
+public class SessionHealthCheckTests
+{
+    // ── WaitForSessionActiveAsync ───────────────────────────────────────
+
+    [Fact]
+    public async Task SessionActiveImmediately_ReturnsTrue()
+    {
+        var result = await SessionHealthCheck.WaitForSessionActiveAsync(
+            _ => true, sessionId: 42, CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task SessionNeverActive_ReturnsFalse()
+    {
+        var result = await SessionHealthCheck.WaitForSessionActiveAsync(
+            _ => false, sessionId: 42, CancellationToken.None,
+            pollMs: 50, timeoutMs: 200);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task SessionBecomesActiveAfterSeveralPolls_ReturnsTrue()
+    {
+        var callCount = 0;
+        var result = await SessionHealthCheck.WaitForSessionActiveAsync(
+            _ => ++callCount >= 4,
+            sessionId: 7, CancellationToken.None,
+            pollMs: 10, timeoutMs: 5000);
+
+        Assert.True(result);
+        Assert.Equal(4, callCount);
+    }
+
+    [Fact]
+    public async Task CancellationStopsPolling()
+    {
+        using var cts = new CancellationTokenSource();
+        var callCount = 0;
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await SessionHealthCheck.WaitForSessionActiveAsync(
+                _ =>
+                {
+                    callCount++;
+                    if (callCount >= 2) cts.Cancel();
+                    return false;
+                },
+                sessionId: 1, cts.Token,
+                pollMs: 10, timeoutMs: 5000);
+        });
+    }
+
+    [Fact]
+    public async Task ActiveCheckOnFinalPollAfterTimeout_ReturnsTrue()
+    {
+        var polls = 0;
+        var result = await SessionHealthCheck.WaitForSessionActiveAsync(
+            _ => ++polls >= 3,
+            sessionId: 99, CancellationToken.None,
+            pollMs: 100, timeoutMs: 250);
+
+        Assert.True(result);
+        Assert.True(polls <= 4);
+    }
+
+    // ── IsWorthChecking (existing, still valid) ─────────────────────────
+
+    [Theory]
+    [InlineData(SeatStatus.Ready)]
+    [InlineData(SeatStatus.Streaming)]
+    public void ALiveSeatIsChecked(SeatStatus status)
+    {
+        Assert.True(SessionHealthCheck.IsWorthChecking(status));
+    }
+
+    [Theory]
+    [InlineData(SeatStatus.Idle)]
+    [InlineData(SeatStatus.Provisioning)]
+    [InlineData(SeatStatus.TearingDown)]
+    [InlineData(SeatStatus.Error)]
+    public void ANonActiveSeatIsNotChecked(SeatStatus status)
+    {
+        Assert.False(SessionHealthCheck.IsWorthChecking(status));
+    }
+}

--- a/src/MultiSeat.Tests/Monitoring/SessionHealthCheckTests.cs
+++ b/src/MultiSeat.Tests/Monitoring/SessionHealthCheckTests.cs
@@ -95,4 +95,25 @@ public class SessionHealthCheckTests
     {
         Assert.False(SessionHealthCheck.IsWorthChecking(status));
     }
+
+    // ── ResolveRecoveryStatus ───────────────────────────────────────
+
+    [Theory]
+    [InlineData(SeatStatus.Ready, true, SeatStatus.Ready)]
+    [InlineData(SeatStatus.Streaming, true, SeatStatus.Streaming)]
+    [InlineData(SeatStatus.Ready, false, SeatStatus.Error)]
+    [InlineData(SeatStatus.Streaming, false, SeatStatus.Error)]
+    // A successful recovery from a non-operational state is anomalous by itself
+    // (CheckSeatAsync only recovers Ready/Streaming seats), so it parks in Error.
+    [InlineData(SeatStatus.Connecting, true, SeatStatus.Error)]
+    [InlineData(SeatStatus.Connecting, false, SeatStatus.Error)]
+    [InlineData(SeatStatus.Idle, true, SeatStatus.Error)]
+    [InlineData(SeatStatus.Provisioning, true, SeatStatus.Error)]
+    [InlineData(SeatStatus.TearingDown, true, SeatStatus.Error)]
+    [InlineData(SeatStatus.Error, true, SeatStatus.Error)]
+    public void ResolveRecoveryStatus_MapsPreviousStateAndOutcome(
+        SeatStatus previous, bool succeeded, SeatStatus expected)
+    {
+        Assert.Equal(expected, SessionHealthCheck.ResolveRecoveryStatus(previous, succeeded));
+    }
 }


### PR DESCRIPTION
Ports the 4 fixes credited in #25 with original authorship preserved (cherry-picked as 0858b04, 44c5dc3, c99d062, 1829b4c from e34f60f, 0167017, 347708a, 46fcae7).

| original | what it fixes |
|---|---|
| e34f60f | session-active gate — do not start Apollo against a session that is not ACTIVE yet |
| 0167017 | orphaned mstsc — TryRemove + KillMstsc before replacing _pendingMstsc entry |
| 347708a | Error-path cleanup — DisconnectSession on the way to Error |
| 46fcae7 | SeatLifecycleGate — per-seat serialization (here as TryReconnectAsync + ResolveRecoveryStatus extraction; the gate itself, DI wiring and endpoint gating already match your port so there is no diff for those files) |

Notes for comparison with your port (201d683 + 287a9c7):
- Conflicts resolved in favor of the originals where they build, except where the trees differ by design: no ISessionLauncher here (kept concrete SessionLauncher + existing serverQuery/loggerFactory wiring), kept your WarnIfApolloDiedOnStartup, lifecycle-gate comments and SeatLifecycleGate/Tests content (functionally identical, yours already credits the fork).
- 5th commit (56f9c91) keeps your intentional deviation from #25: WaitForSessionActiveAsync throws on an already-cancelled token instead of returning false, so PropagatesCancellation stays green. Originals 1-4 are untouched above it for comparison.
- Build: 0 errors. Tests: 25/25 green (SessionHealthCheck + WaitForSessionActive + SeatLifecycleGate).

Upstream already contains your adapted port, so this is expected to overlap — opening it anyway per your ask in #25 so the authorship lives in the history. Close or replace 201d683 as you prefer; no refactor included here, that stays a separate conversation.