### PR TITLE
fix(seats): lock the seat config directory to SYSTEM, Admins and the seat

### DIFF
--- a/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
+++ b/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
@@ -56,6 +56,11 @@ public sealed class ApolloConfigBuilder
             throw new InvalidOperationException(
                 $"Account name '{seat.AccountName}' would escape the Apollo config directory.");
         Directory.CreateDirectory(seatDir);
+        // Lock the seat directory before anything is written into it (GH #28). Left inheriting, it
+        // carries ProgramData's BUILTIN\Users:(W) on the directory itself, so any local account -
+        // including every other seat - can create files here. Re-applied on every provision, so an
+        // existing host is fixed the next time its seats come up rather than needing a migration.
+        ProtectSeatDirectory(seatDir, seat.AccountName, SeatDirConsequence);
 
         var configPath = Path.Combine(seatDir, "sunshine.conf");
         // Requested, not guaranteed: some builds ignore log_path (Vibepollo writes timestamped
@@ -389,7 +394,7 @@ public sealed class ApolloConfigBuilder
         // carries ProgramData's BUILTIN\Users:(RX), so every standard user on the host -
         // including every OTHER seat - can read the TLS private key and impersonate this
         // seat's pairing endpoint.
-        ProtectSeatCredentialsDir(credDir, accountName);
+        ProtectSeatDirectory(credDir, accountName, CredentialsDirConsequence);
 
         // Apollo uses relative paths for its assets and tools directories
         // (e.g. ./assets/shaders/ for GPU shaders). Create junction points so
@@ -548,6 +553,11 @@ public sealed class ApolloConfigBuilder
     private const string LogFileConsequence =
         "this seat's Apollo will run but write no log at all, so the next fault on this seat has "
         + "to be diagnosed blind";
+    private const string CredentialsDirConsequence =
+        "its TLS private key stays readable by every local user";
+    private const string SeatDirConsequence =
+        "every local user - including every OTHER seat - can keep creating files in this seat's "
+        + "directory, so a planted apollo*.log can impersonate or suppress this seat's real log";
 
     /// <summary>
     /// Make sure the seat can write the log its Apollo is about to open.
@@ -717,11 +727,22 @@ public sealed class ApolloConfigBuilder
     /// entries on children when a parent's inheritable entries change.
     ///
     /// If the seat account cannot be resolved this does NOTHING and says so. Protecting the
-    /// directory without granting the seat would leave Apollo unable to read or write its own key,
-    /// which breaks the seat outright - a worse outcome than the exposure this closes, and that
-    /// exposure is the state the host was already in.
+    /// directory without granting the seat would leave Apollo unable to read or write its own
+    /// files, which breaks the seat outright - a worse outcome than the exposure this closes, and
+    /// that exposure is the state the host was already in.
+    ///
+    /// Used for two directories, and the seat one matters most (GH #28). ProgramData grants
+    /// BUILTIN\Users Write on the seat directory itself - ContainerInherit without ObjectInherit,
+    /// so existing files are safe but the directory is not - which let any local account, including
+    /// every OTHER seat, create files there. That is reachable: ApolloManager.ResolveLogPath picks
+    /// the newest apollo*.log by write time, and OnConnectAppLauncher acts on its CLIENT CONNECTED
+    /// lines, so a planted file could drive or suppress another seat's connect handling.
+    ///
+    /// ⭐ Applying this to the seat directory also makes the seat's Modify grant INHERITED rather
+    /// than a single explicit ACE per file, so a file replaced by rename keeps it. The explicit
+    /// GrantSeatWrite calls stay as defence in depth - do not remove them on the strength of this.
     /// </summary>
-    private void ProtectSeatCredentialsDir(string credDir, string accountName)
+    private void ProtectSeatDirectory(string dir, string accountName, string consequence)
     {
         SecurityIdentifier sid;
         try
@@ -734,23 +755,21 @@ public sealed class ApolloConfigBuilder
             _logger.LogWarning(
                 ex,
                 "Could not resolve {Account} to a SID, so {Dir} keeps its inherited permissions - "
-                + "its TLS private key stays readable by every local user",
-                accountName, credDir);
+                + "{Consequence}",
+                accountName, dir, consequence);
             return;
         }
 
         try
         {
-            new DirectoryInfo(credDir).SetAccessControl(BuildSeatCredentialsAcl(sid));
+            new DirectoryInfo(dir).SetAccessControl(BuildSeatCredentialsAcl(sid));
             _logger.LogInformation(
-                "Restricted {Dir} to SYSTEM, Administrators and {Account}", credDir, accountName);
+                "Restricted {Dir} to SYSTEM, Administrators and {Account}", dir, accountName);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(
-                ex,
-                "Could not restrict {Dir} - its TLS private key stays readable by every local user",
-                credDir);
+                ex, "Could not restrict {Dir} - {Consequence}", dir, consequence);
         }
     }
 

--- a/src/MultiSeat.Service/Streaming/ApolloManager.cs
+++ b/src/MultiSeat.Service/Streaming/ApolloManager.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Options;
 using MultiSeat.Service.Configuration;
@@ -352,6 +354,11 @@ public sealed class ApolloManager
 
         try
         {
+            // The seat directory is named for the account, so the owner we expect is derivable
+            // without threading it through both call sites.
+            var seatSid = ResolveAccountSid(Path.GetFileName(seatDir.TrimEnd(
+                Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)));
+
             FileInfo? newest = null;
             foreach (var dir in new[] { seatDir, Path.Combine(seatDir, "logs") })
             {
@@ -360,6 +367,7 @@ public sealed class ApolloManager
                 foreach (var candidate in new DirectoryInfo(dir).EnumerateFiles("apollo*.log"))
                 {
                     if (!HasContent(candidate)) continue;
+                    if (!IsTrustedLogOwner(OwnerOf(candidate), seatSid)) continue;
                     if (newest is null || candidate.LastWriteTimeUtc > newest.LastWriteTimeUtc)
                         newest = candidate;
                 }
@@ -387,6 +395,64 @@ public sealed class ApolloManager
     /// because the streaming binary holds the log open for writing the whole time.
     /// A file we cannot open is one we could not read later either, so it counts as empty.
     /// </summary>
+    /// <summary>
+    /// Whether a candidate log may be believed, judged by who owns it (GH #28).
+    ///
+    /// <see cref="ResolveLogPath"/> picks a log by filename pattern and write time, and
+    /// <c>OnConnectAppLauncher</c> then acts on its "CLIENT CONNECTED" lines. Both of those are
+    /// forgeable by anyone who can create a file in the seat directory. Ownership is not: a planted
+    /// file is owned by whoever planted it.
+    ///
+    /// Only two accounts legitimately author these. Apollo runs as the seat, so the seat owns its
+    /// own log; MultiSeat runs as SYSTEM, so SYSTEM owns anything the service creates.
+    ///
+    /// ⚠️ Fails OPEN, deliberately, on BOTH unknowns - an owner that cannot be read and a seat
+    /// account that does not resolve. Excluding on doubt would hand back the requested path and
+    /// silently blind display detection and launch-on-connect, which is the regression the pattern
+    /// search exists to avoid in the first place. ⛔ Getting this wrong is not theoretical: an
+    /// earlier draft filtered when only the owner was unknown, which excluded every candidate any
+    /// time the account failed to resolve. Four ResolveLogPath tests caught it.
+    ///
+    /// The directory ACL applied in ApolloConfigBuilder is the control that actually closes GH #28.
+    /// This is defence in depth, and it covers the window on an existing host before its seats next
+    /// provision.
+    /// </summary>
+    internal static bool IsTrustedLogOwner(SecurityIdentifier? owner, SecurityIdentifier? seatSid)
+    {
+        // Both unknowns fail open, and for the same reason: filtering on a comparison we cannot
+        // make would exclude every candidate and hand back the requested path, blinding display
+        // detection and launch-on-connect on a host that has done nothing wrong.
+        if (owner is null) return true;    // owner unreadable
+        if (seatSid is null) return true;  // seat account did not resolve, so there is nothing to compare against
+
+        if (owner.IsWellKnown(WellKnownSidType.LocalSystemSid)) return true;
+        if (owner.IsWellKnown(WellKnownSidType.BuiltinAdministratorsSid)) return true;
+
+        return owner.Equals(seatSid);
+    }
+
+    /// <summary>Owner SID of a file, or null when it cannot be read.</summary>
+    private static SecurityIdentifier? OwnerOf(FileInfo file)
+    {
+        try
+        {
+            return file.GetAccessControl().GetOwner(typeof(SecurityIdentifier)) as SecurityIdentifier;
+        }
+        catch (Exception) { return null; }
+    }
+
+    /// <summary>Local account name to SID, or null when it does not resolve.</summary>
+    private static SecurityIdentifier? ResolveAccountSid(string accountName)
+    {
+        if (string.IsNullOrWhiteSpace(accountName)) return null;
+        try
+        {
+            return (SecurityIdentifier)new NTAccount(Environment.MachineName, accountName)
+                .Translate(typeof(SecurityIdentifier));
+        }
+        catch (Exception) { return null; }
+    }
+
     private static bool HasContent(FileInfo file)
     {
         try

--- a/src/MultiSeat.Tests/Streaming/StreamingTests.cs
+++ b/src/MultiSeat.Tests/Streaming/StreamingTests.cs
@@ -1048,6 +1048,55 @@ public class StreamingTests
         finally { DeleteTestDir(seatDir); }
     }
 
+    // ── ApolloManager.IsTrustedLogOwner (GH #28) ─────────────────────────
+    // ResolveLogPath picks a log by name pattern and write time, and OnConnectAppLauncher then
+    // acts on its CLIENT CONNECTED lines. Both are forgeable by anyone who can create a file in
+    // the seat directory. Ownership is not, so it is the tiebreak.
+
+    private static SecurityIdentifier Sid(string value) => new(value);
+    private static SecurityIdentifier SeatAccountSid() => Sid("S-1-5-21-99-99-99-1001");
+    private static SecurityIdentifier OtherAccountSid() => Sid("S-1-5-21-99-99-99-1002");
+
+    [Fact]
+    public void IsTrustedLogOwner_RejectsAFileOwnedByAnotherAccount()
+    {
+        // The whole point: another seat plants apollo-evil.log, and it must not be selected.
+        Assert.False(ApolloManager.IsTrustedLogOwner(OtherAccountSid(), SeatAccountSid()));
+    }
+
+    [Fact]
+    public void IsTrustedLogOwner_AcceptsTheSeatsOwnLog()
+    {
+        // Apollo runs as the seat, so the seat owns the log it writes.
+        Assert.True(ApolloManager.IsTrustedLogOwner(SeatAccountSid(), SeatAccountSid()));
+    }
+
+    [Fact]
+    public void IsTrustedLogOwner_AcceptsSystemAndAdministrators()
+    {
+        // MultiSeat runs as SYSTEM, so the service owns anything it creates.
+        Assert.True(ApolloManager.IsTrustedLogOwner(
+            new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null), SeatAccountSid()));
+        Assert.True(ApolloManager.IsTrustedLogOwner(
+            new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null), SeatAccountSid()));
+    }
+
+    [Fact]
+    public void IsTrustedLogOwner_FailsOpenWhenTheOwnerCannotBeRead()
+    {
+        Assert.True(ApolloManager.IsTrustedLogOwner(null, SeatAccountSid()));
+    }
+
+    [Fact]
+    public void IsTrustedLogOwner_FailsOpenWhenTheSeatAccountDoesNotResolve()
+    {
+        // ⛔ Regression guard. An earlier draft only failed open on an unreadable owner, so an
+        // unresolvable account excluded EVERY candidate and handed back the requested path —
+        // silently blinding display detection and launch-on-connect, which is the exact failure
+        // the pattern search exists to avoid. Four ResolveLogPath tests caught it.
+        Assert.True(ApolloManager.IsTrustedLogOwner(OtherAccountSid(), null));
+    }
+
     // -- Dangling junction repair --------------------------------------
     //
     // Apollo resolves SUNSHINE_ASSETS_DIR ("assets", a RELATIVE string on Windows) against its


### PR DESCRIPTION
Closes #28.

## The problem

ProgramData grants `BUILTIN\Users` **Write on the seat directory itself** — `ContainerInherit`
without `ObjectInherit`, so existing files were safe but the directory was not. Any local account,
including every other seat, could create files in another seat's directory.

That is reachable rather than theoretical. `ApolloManager.ResolveLogPath` selects a log by matching
`apollo*.log` and taking the newest write time, and `OnConnectAppLauncher` then acts on that file's
`CLIENT CONNECTED` lines, so a planted file could drive or suppress another seat's connect handling.

⛔ It is **not** arbitrary code execution — the launched apps come from `LaunchOnConnect`, which the
administrator configures, so an attacker influences *when* a launch happens, not *what* runs. A
default install is unaffected entirely, since `LaunchOnConnect` is empty and `ProcessSeat` returns
immediately when it is. It does cross the seat isolation boundary, which is the property the project
exists to provide.

## The fix

`ProtectSeatCredentialsDir` is generalised to `ProtectSeatDirectory(dir, account, consequence)` and
applied to the **seat directory** immediately after creation, before anything is written into it,
reusing the existing `BuildSeatCredentialsAcl`. It is re-applied on every provision, so an existing
host heals the next time its seats come up rather than needing a migration.

Measured after deploy — `BUILTIN\Users` is gone from the whole seat tree:

```
apollo\<seat>\      protected (no inheritance), exactly 3 ACEs:
                      NT AUTHORITY\SYSTEM       FullControl
                      BUILTIN\Administrators    FullControl
                      <HOST>\<seat>            Modify, Synchronize
apollo\<seat>\config\   inherits those three
```

⭐ Why that is conclusive for other seats: seat accounts are members of `Users`, **not**
Administrators, and there is no longer any `Users` ACE. No matching ACE, no access, and inheritance
is off so nothing else applies.

⭐ Side effect worth knowing: the seat's Modify grant becomes **inherited** rather than one explicit
ACE per file, so a file replaced by rename keeps it. That mitigates the ACE-after-rename problem
raised in #27. The explicit `GrantSeatWrite` calls are deliberately left in place as defence in
depth.

## Second layer: ownership

`ResolveLogPath` now skips candidates whose owner is not the seat, SYSTEM, or Administrators. Only
two accounts legitimately author these logs — Apollo runs as the seat, MultiSeat runs as SYSTEM — and
while filename and write time are forgeable, ownership is not. This covers the window on an existing
host before its seats next provision.

⚠️ It fails **open** on both unknowns: an unreadable owner and an unresolvable seat account. An
earlier draft only handled the first, which excluded every candidate whenever the account failed to
resolve and silently blinded display detection and launch-on-connect. Four `ResolveLogPath` tests
caught it, and there is now a named regression guard.

## Deliberately not done

⛔ **Preferring the flat `apollo.log` over the pattern search.** I proposed this on #28 and it is
wrong. Vibepollo ignores `log_path` and writes timestamped files under `logs\`, so preferring the
requested name reintroduces exactly the regression the pattern search exists to avoid — the test
header records that it "silently disabled SudoVDA display detection and launch-on-connect."

## Verification

- **475 unit tests pass**, up from 470. Five are new, covering the trust predicate including both
  fail-open paths.
- **`smoke-seat.ps1`: 24 checks, 0 failed** — including the three permission checks that were the
  sequencing risk, since tightening the directory must not strip the seat's Modify on `apps.json`
  and `sunshine_state.json`.
- **Planted-file rejection proven with a control.** With the seat SID resolvable, a seat-owned log
  two hours older wins over a newer file owned by another account. Rename the directory so the SID
  cannot resolve and the newer planted file wins instead — proving the filter, not the timestamp,
  caused the result.
- **A real Moonlight session to a seat**, which is the case a green smoke test cannot cover. Display
  detection healthy (`Desktop resolution [1920x1080]`), HEVC NVENC encoder created, the owner filter
  selecting the real seat-owned log, and the ACL still showing three ACEs mid-stream.
