### PR TITLE
fix(seats): re-grant the seat's ACE after the atomic state write

### DIFF
--- a/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
+++ b/src/MultiSeat.Service/Streaming/ApolloConfigBuilder.cs
@@ -1116,7 +1116,7 @@ public sealed class ApolloConfigBuilder
 
             if (removed)
             {
-                WriteStateFile(statePath, node!);
+                WriteStateFile(statePath, accountName, node!);
                 _logger.LogInformation("Unpaired client '{Name}' from seat {Account}", clientName, accountName);
             }
 
@@ -1146,7 +1146,7 @@ public sealed class ApolloConfigBuilder
             if (devices == null) return;
 
             devices.Clear();
-            WriteStateFile(statePath, node!);
+            WriteStateFile(statePath, accountName, node!);
             _logger.LogInformation("Unpaired all clients from seat {Account}", accountName);
         }
         catch (Exception ex)
@@ -1158,12 +1158,33 @@ public sealed class ApolloConfigBuilder
     private static string GetStateFilePath(string accountName, string configDir) =>
         Path.Combine(configDir, accountName, "config", "sunshine_state.json");
 
-    // Atomic read-modify-write: Apollo holds pairing state in memory and rewrites this
-    // file, so a torn write loses pairings with no error at either end (see GrantSeatWrite).
-    private static void WriteStateFile(string path, JsonNode node) =>
+    /// <summary>
+    /// Atomic read-modify-write of a seat's pairing state. Apollo holds that state in memory and
+    /// rewrites the file, so a torn write loses pairings with no error at either end.
+    ///
+    /// ⛔ The re-grant is not optional. <see cref="AtomicFile.WriteAllText"/> replaces the target by
+    /// rename, and a renamed file is a NEW file object that carries none of the explicit ACEs the
+    /// old one had — including the seat's Modify, which is granted per file by
+    /// <see cref="GrantSeatWrite"/>. Without this the seat's Apollo silently loses write access to
+    /// its own pairing state after any unpair, and the failure only shows up on the NEXT pairing
+    /// request. That is exactly what <see cref="StateFileConsequence"/> describes.
+    ///
+    /// ⚠️ This method was `static` when the atomic write was introduced, which is how it shipped
+    /// without the re-grant while both sibling call sites had one — a static helper has no
+    /// accountName to grant with. Keep it an instance method.
+    ///
+    /// ⚠️ Since the seat directory is locked down (GH #28) the seat also inherits Modify from the
+    /// directory, so on a current host this grant is belt as well as braces. Do not remove it on
+    /// that basis: relying on directory inheritance to cover a missing per-file grant breaks
+    /// quietly if that ACL is ever loosened.
+    /// </summary>
+    private void WriteStateFile(string path, string accountName, JsonNode node)
+    {
         AtomicFile.WriteAllText(path,
             node.ToJsonString(new JsonSerializerOptions { WriteIndented = true }),
             Encoding.UTF8);
+        GrantSeatWrite(path, accountName, StateFileConsequence);
+    }
 
     // ── NVENC preset tables ───────────────────────────────────────────────
 

--- a/src/MultiSeat.Tests/Streaming/ApolloConfigAtomicTests.cs
+++ b/src/MultiSeat.Tests/Streaming/ApolloConfigAtomicTests.cs
@@ -21,6 +21,36 @@ namespace MultiSeat.Tests.Streaming;
 /// </summary>
 public class ApolloConfigAtomicTests
 {
+    // ── GH #28 follow-up: the re-grant that the atomic write made necessary ──
+    //
+    // AtomicFile replaces a file by rename, and a renamed file is a NEW file object carrying
+    // none of the explicit ACEs the old one had — including the seat's Modify, granted per file
+    // by GrantSeatWrite. Two of the three AtomicFile call sites re-granted; WriteStateFile did
+    // not, because it was `static` and so had no accountName to grant with.
+    //
+    // The consequence is silent and delayed: after an unpair the seat's Apollo cannot write its
+    // own pairing state, and nothing fails until the NEXT pairing request.
+    //
+    // Asserting the ACL itself would need a real local account and elevation, so this pins the
+    // structural property that made the bug possible instead — it is fast, deterministic, and
+    // fails the moment someone makes the helper static again.
+
+    [Fact]
+    public void WriteStateFile_IsAnInstanceMethodTakingAnAccountName_soItCanReGrant()
+    {
+        var m = typeof(ApolloConfigBuilder).GetMethod(
+            "WriteStateFile",
+            System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Public);
+
+        Assert.NotNull(m);
+        Assert.False(m!.IsStatic, "WriteStateFile must stay an instance method: a static helper has "
+            + "no accountName and cannot call GrantSeatWrite after the rename (GH #28).");
+        Assert.Contains(m.GetParameters(), p => p.ParameterType == typeof(string)
+            && string.Equals(p.Name, "accountName", System.StringComparison.Ordinal));
+    }
+
     [Fact]
     public void UpdateDisplayOutput_ChangesOnlyTargetLine_ByteIdenticalElsewhere()
     {

--- a/src/MultiSeat.Tests/Streaming/SeatStateReGrantTests.cs
+++ b/src/MultiSeat.Tests/Streaming/SeatStateReGrantTests.cs
@@ -1,0 +1,150 @@
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MultiSeat.Service.Configuration;
+using MultiSeat.Service.Streaming;
+using Xunit;
+
+namespace MultiSeat.Tests.Streaming;
+
+/// <summary>
+/// GH #28 follow-up: a seat's explicit Modify ACE must survive the atomic rewrite of its
+/// pairing state.
+///
+/// <see cref="AtomicFile"/> replaces a file by rename, and a renamed file is a NEW file object
+/// carrying none of the explicit ACEs the old one had. <c>GrantSeatWrite</c> applies the seat's
+/// Modify per file, so every AtomicFile call site has to re-grant afterwards. Two did;
+/// <c>WriteStateFile</c> did not, because it was <c>static</c> and had no accountName to grant
+/// with. The consequence is silent and delayed — after an unpair the seat's Apollo cannot write
+/// its own pairing state, and nothing fails until the NEXT pairing request.
+///
+/// <see cref="ApolloConfigAtomicTests"/> pins the structural property (not static, takes an
+/// accountName). This pins the behaviour it exists to produce, which is the thing that actually
+/// matters, and it is the only test here that would catch a re-grant that was present but wrong.
+///
+/// ⚠️ The seat directory is deliberately set up the way a post-#28 host looks — protected, with
+/// the account's Modify inheritable. That means the file also picks up an INHERITED Modify, so
+/// the assertion is specifically about an **explicit** (non-inherited) entry. Asserting merely
+/// "the account can write" would pass on a broken build, because inheritance alone satisfies it.
+/// </summary>
+public class SeatStateReGrantTests
+{
+    /// <summary>
+    /// The account to act as. Any resolvable LOCAL account works — the production code does
+    /// <c>new NTAccount(Environment.MachineName, accountName)</c> — so the current user is used
+    /// rather than depending on a seat account existing on the machine.
+    /// </summary>
+    private static string? LocalAccountName()
+    {
+        var parts = WindowsIdentity.GetCurrent().Name.Split('\\');
+        if (parts.Length != 2) return null;
+        if (!string.Equals(parts[0], Environment.MachineName, StringComparison.OrdinalIgnoreCase))
+            return null; // domain account: NTAccount(machine, name) would not resolve
+
+        try
+        {
+            _ = (SecurityIdentifier)new NTAccount(Environment.MachineName, parts[1])
+                .Translate(typeof(SecurityIdentifier));
+            return parts[1];
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static ApolloConfigBuilder NewBuilder() => new(
+        NullLogger<ApolloConfigBuilder>.Instance,
+        Options.Create(new MultiSeatOptions()));
+
+    [Fact]
+    public void UnpairAllClients_ReGrantsTheSeatsExplicitAce_afterTheAtomicRename()
+    {
+        var account = LocalAccountName();
+        // Loud rather than a silent skip: a vacuous pass on an unsupported host would be worse
+        // than no test, and windows-latest runners use a local account.
+        Assert.True(account is not null,
+            "Could not resolve a local account for the current user, so this test cannot run. "
+            + "It needs an account that NTAccount(MachineName, name) resolves.");
+
+        var sid = (SecurityIdentifier)new NTAccount(Environment.MachineName, account!)
+            .Translate(typeof(SecurityIdentifier));
+
+        var root = Path.Combine(Path.GetTempPath(), "ms-regrant-" + Guid.NewGuid().ToString("N"));
+        var seatDir = Path.Combine(root, account!);
+        var configDir = Path.Combine(seatDir, "config");
+        Directory.CreateDirectory(configDir);
+
+        try
+        {
+            // Make the seat dir look like a post-#28 host: protected, account Modify inheritable.
+            var dirAcl = new DirectorySecurity();
+            dirAcl.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+            const InheritanceFlags Inherit = InheritanceFlags.ObjectInherit | InheritanceFlags.ContainerInherit;
+            dirAcl.AddAccessRule(new FileSystemAccessRule(
+                new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+                FileSystemRights.FullControl, Inherit, PropagationFlags.None, AccessControlType.Allow));
+            dirAcl.AddAccessRule(new FileSystemAccessRule(
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                FileSystemRights.FullControl, Inherit, PropagationFlags.None, AccessControlType.Allow));
+            dirAcl.AddAccessRule(new FileSystemAccessRule(
+                sid, FileSystemRights.Modify, Inherit, PropagationFlags.None, AccessControlType.Allow));
+            new DirectoryInfo(seatDir).SetAccessControl(dirAcl);
+
+            // A device to clear, so the assertion below proves the method actually ran rather
+            // than returning early.
+            var statePath = Path.Combine(configDir, "sunshine_state.json");
+            File.WriteAllText(
+                statePath,
+                """{"root":{"named_devices":[{"name":"probe","perm":119480064}]}}""",
+                Encoding.UTF8);
+
+            // Strip any explicit entry, so only a re-grant can put one back.
+            var before = new FileInfo(statePath).GetAccessControl();
+            foreach (FileSystemAccessRule r in before.GetAccessRules(true, false, typeof(SecurityIdentifier)))
+                before.RemoveAccessRuleSpecific(r);
+            new FileInfo(statePath).SetAccessControl(before);
+
+            Assert.False(
+                HasExplicitAce(statePath, sid),
+                "precondition: the state file must start with no explicit ACE for the account");
+
+            NewBuilder().UnpairAllClients(account!, root);
+
+            // Proves the method ran: it clears named_devices and rewrites the file.
+            using (var doc = JsonDocument.Parse(File.ReadAllText(statePath)))
+            {
+                Assert.Equal(
+                    0,
+                    doc.RootElement.GetProperty("root").GetProperty("named_devices").GetArrayLength());
+            }
+
+            Assert.True(
+                HasExplicitAce(statePath, sid),
+                "the atomic rename dropped the seat's explicit Modify ACE and it was not re-granted; "
+                + "after an unpair the seat's Apollo cannot write its own pairing state, and the "
+                + "failure only surfaces on the next pairing request");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// An <b>explicit</b> (non-inherited) allow rule granting the SID write access. Inherited
+    /// entries are ignored on purpose — on a post-#28 host the account inherits Modify from the
+    /// directory, so counting those would pass on a build with no re-grant at all.
+    /// </summary>
+    private static bool HasExplicitAce(string path, SecurityIdentifier sid) =>
+        new FileInfo(path)
+            .GetAccessControl()
+            .GetAccessRules(includeExplicit: true, includeInherited: false, typeof(SecurityIdentifier))
+            .Cast<FileSystemAccessRule>()
+            .Any(r => r.AccessControlType == AccessControlType.Allow
+                && r.IdentityReference.Equals(sid)
+                && (r.FileSystemRights & FileSystemRights.Write) == FileSystemRights.Write);
+}


### PR DESCRIPTION
Follow-up to the atomic-write series merged in #27, addressing the `CHANGES_REQUESTED` left on it.

`AtomicFile` replaces a file by rename, and a renamed file is a new file object carrying none of
the explicit ACEs the old one had — including the seat's Modify, applied per file by
`GrantSeatWrite`. Two of the three `AtomicFile` call sites re-grant afterwards; `WriteStateFile`
did not, because it was `static` and so had no `accountName` to grant with.

Both callers are the dashboard's unpair actions (`SeatEndpoints.cs:323`, `:330`), so after any
unpair the seat's Apollo lost write access to its own pairing state. The failure is silent and
delayed — pairing appears to succeed and is refused on the *next* request, exactly as
`StateFileConsequence` describes.

`WriteStateFile` is now an instance method taking `accountName`, calling `GrantSeatWrite` after
the write.

⚠️ Since #28 locked the seat directory down, the seat also inherits Modify from the directory, so
on a current host this is belt as well as braces. The per-file grant stays regardless: relying on
directory inheritance to cover a missing grant breaks quietly if that ACL is ever loosened.

## Tests

Two, because they catch different things.

**Structural** — `WriteStateFile` must not be `static` and must take an `accountName`. That pins
the mistake that caused the bug. It cannot catch a re-grant that is present but wrong.

**Behavioural** — sets a seat directory up the way a post-#28 host looks (protected, account
Modify inheritable), strips the explicit ACE from the state file, calls `UnpairAllClients`, and
asserts an explicit non-inherited ACE is back.

Two details make the second one discriminating rather than decorative:

- **Inherited entries are excluded from the assertion.** On a post-#28 host the account inherits
  Modify from the directory, so asserting merely "can the account write" would pass on a build
  with no re-grant at all.
- **The state file is seeded with a device the method clears**, and the test asserts
  `named_devices` ends up empty. That proves the method actually ran rather than returning early —
  a test that reports success when the code under test never executed is worse than no test.

Validated by removing the `GrantSeatWrite` call and confirming the behavioural test fails, then
restoring it and confirming it passes.

⚠️ It uses the **current user** rather than a seat account, since the production code resolves
`NTAccount(MachineName, name)` and any local account satisfies that. If no local account resolves
— a domain-joined runner — it fails loudly rather than skipping, because xunit 2.x has no dynamic
skip and a vacuous pass would be worse than no test.

**508 tests pass**, up from 507.
