### PR TITLE
fix: gate on RDP Wrapper, and name it as the cause when a seat times out

### DIFF
--- a/scripts/install-service.ps1
+++ b/scripts/install-service.ps1
@@ -242,6 +242,104 @@ Write-Host ""
 # The real fix is signing the generated .rdp with rdpsign.exe and trusting the thumbprint
 # via the TrustedCertThumbprints policy. Not done yet.
 
+# -- RDP Wrapper check ------------------------------------------------
+# Every seat IS an RDP session, so without multi-session RDP no seat can ever start.
+# This script used to gate on SudoVDA and the audio cables but say nothing about the one
+# dependency nothing works without: it would register and start the service on a host where
+# seats were impossible, and the first sign the user got was a seat timing out (issue #33).
+#
+# Before 0.6.0 that was masked -- installing meant cloning the repo, so prerequisites\ was
+# in front of you. The zip install removed the clone and with it the reminder.
+#
+# Test BEHAVIOUR, not presence: an installed wrapper whose ini has no section for this
+# host's termsrv.dll is inactive, and looks identical to a correct install from the outside.
+# This mirrors RdpWrapper.EnsureMultiSession() in the service so the two cannot disagree.
+Write-Step "Checking RDP Wrapper (multi-session support)..."
+
+# termsrv.dll's StringFileInfo and its VS_FIXEDFILEINFO DISAGREE -- measured 2026-09-01, the
+# string said 10.0.26100.8115 while the raw fixed-info said .8972, and the raw one is what
+# RDPWrap keys on. Read FileVersionRaw and never fall back to the string.
+function Get-TermSrvVersionForGate {
+    $termsrv = Join-Path $env:SystemRoot "System32\termsrv.dll"
+    if (-not (Test-Path $termsrv)) { return $null }
+    $raw = (Get-Item $termsrv).VersionInfo.FileVersionRaw
+    if (-not $raw) { return $null }
+    return ("{0}.{1}.{2}.{3}" -f $raw.Major, $raw.Minor, $raw.Build, $raw.Revision)
+}
+
+# BOTH sections are required. RDPWrap patches with whatever it finds, so a half-present
+# pair is worse than none.
+function Test-RdpWrapCoverage($iniPath, $version) {
+    if (-not $version -or -not $iniPath -or -not (Test-Path $iniPath)) { return $false }
+    $ini = Get-Content $iniPath
+    $main   = [bool]($ini | Select-String -SimpleMatch -Pattern "[$version]"        -Quiet)
+    $slInit = [bool]($ini | Select-String -SimpleMatch -Pattern "[$version-SLInit]" -Quiet)
+    return ($main -and $slInit)
+}
+
+$script:RdpWrapProblem = $null
+$rdpWrapDll = $null
+$rdpWrapIni = $null
+
+$sys32Dll = Join-Path $env:SystemRoot "System32\rdpwrap.dll"
+if (Test-Path $sys32Dll) {
+    # Classic install: rdpwrap.dll dropped into System32.
+    $rdpWrapDll = $sys32Dll
+    $classicIni = Join-Path ${env:ProgramFiles} "RDP Wrapper\rdpwrap.ini"
+    if (Test-Path $classicIni) { $rdpWrapIni = $classicIni }
+} else {
+    # ServiceDll install (RDPWrap 1.6.2+, and TermWrap): TermService redirected away from
+    # the stock termsrv.dll. Do NOT require the name "rdpwrap" -- TermWrap is a different
+    # patch that works the same way, and demanding the name reported a working host as
+    # broken in issue #15. What matters is that the redirect exists.
+    try {
+        $svcDll = (Get-ItemProperty `
+            'HKLM:\SYSTEM\CurrentControlSet\Services\TermService\Parameters' `
+            -Name ServiceDll -ErrorAction Stop).ServiceDll
+        if ($svcDll) {
+            $expanded = [Environment]::ExpandEnvironmentVariables($svcDll)
+            if ((Split-Path $expanded -Leaf) -ne 'termsrv.dll' -and (Test-Path $expanded)) {
+                $rdpWrapDll = $expanded
+                # Only RDPWrap is keyed by an offsets ini. No sibling ini means the patch
+                # finds its offsets another way, and there is nothing to validate.
+                $sibling = Join-Path (Split-Path $expanded -Parent) "rdpwrap.ini"
+                if (Test-Path $sibling) { $rdpWrapIni = $sibling }
+            }
+        }
+    } catch {
+        # No ServiceDll value at all -- stock TermService. Handled as "not found" below.
+    }
+}
+
+$termSrvVersion = Get-TermSrvVersionForGate
+
+if (-not $rdpWrapDll) {
+    $script:RdpWrapProblem = "not installed"
+    Write-Host ""
+    Write-Host "  *** WARNING: no multi-session patch found. ***" -ForegroundColor Red
+    Write-Host "  No rdpwrap.dll in System32, and TermService still points at the stock" -ForegroundColor Yellow
+    Write-Host "  termsrv.dll. Every seat is an RDP session, so NO SEAT CAN START." -ForegroundColor Yellow
+    Write-Host "  Run prerequisites\install-prerequisites.ps1 to install RDP Wrapper." -ForegroundColor Yellow
+    Write-Host ""
+} elseif (-not $rdpWrapIni) {
+    Write-Host "  OK: multi-session patch at $rdpWrapDll (not ini-keyed, nothing to verify)" -ForegroundColor DarkGray
+} elseif (Test-RdpWrapCoverage $rdpWrapIni $termSrvVersion) {
+    Write-Host "  OK: RDP Wrapper covers termsrv $termSrvVersion" -ForegroundColor DarkGray
+} elseif (-not $termSrvVersion) {
+    Write-Host "  WARNING: could not read termsrv.dll's version -- coverage unverified." -ForegroundColor Yellow
+} else {
+    $script:RdpWrapProblem = "installed but does not cover termsrv $termSrvVersion"
+    Write-Host ""
+    Write-Host "  *** WARNING: RDP Wrapper is installed but INACTIVE. ***" -ForegroundColor Red
+    Write-Host "  $rdpWrapIni has no section pair for termsrv $termSrvVersion," -ForegroundColor Yellow
+    Write-Host "  which a Windows update almost certainly replaced. Every seat is an RDP" -ForegroundColor Yellow
+    Write-Host "  session, so NO SEAT CAN START until this build is covered." -ForegroundColor Yellow
+    Write-Host "  Fix: prerequisites\install-prerequisites.ps1 refreshes the ini, and" -ForegroundColor Yellow
+    Write-Host "       scripts\check-rdpwrap-offsets.ps1 -Generate computes the offsets" -ForegroundColor Yellow
+    Write-Host "       locally if the community ini has not caught up yet." -ForegroundColor Yellow
+    Write-Host ""
+}
+
 # -- SudoVDA check ---------------------------------------------------
 # SudoVDA is required for per-seat virtual display isolation.
 # Without it, Apollo captures the primary physical display and all seats
@@ -615,3 +713,17 @@ Write-Host "`n[MultiSeat] Service installed and $($svc.Status)!" -ForegroundColo
 Write-Host "  Dashboard: http://localhost:9550"
 Write-Host "  Logs:      Windows Event Log (Application / MultiSeat.Service) -- run scripts\show-logs.ps1"
 Write-Host "  Config:    $InstallDir\appsettings.json"
+
+# Repeat the RDP Wrapper verdict LAST. It was already printed above, but a successful
+# "Service installed" is what the user reads, and a warning several screens up is a
+# warning nobody sees -- which is how issue #33 arrived as a seat timeout instead.
+if ($script:RdpWrapProblem) {
+    Write-Host ""
+    Write-Host "  ================================================================" -ForegroundColor Red
+    Write-Host "  NO SEAT WILL START YET: RDP Wrapper is $($script:RdpWrapProblem)." -ForegroundColor Red
+    Write-Host "  Every seat is an RDP session. The service is installed and running," -ForegroundColor Yellow
+    Write-Host "  but seats will fail with a session timeout until you run:" -ForegroundColor Yellow
+    Write-Host "      prerequisites\install-prerequisites.ps1" -ForegroundColor White
+    Write-Host "  Then re-check with: scripts\check-rdpwrap-offsets.ps1" -ForegroundColor Yellow
+    Write-Host "  ================================================================" -ForegroundColor Red
+}

--- a/src/MultiSeat.Service/Sessions/SessionLauncher.cs
+++ b/src/MultiSeat.Service/Sessions/SessionLauncher.cs
@@ -71,17 +71,27 @@ public sealed class SessionLauncher
     /// </summary>
     private readonly RdpCredentialStore _credentials;
 
+    /// <summary>
+    /// Consulted only when a seat's session fails to appear, to say WHY in the exception.
+    /// Every seat is an RDP session, so an inactive wrapper means no seat can ever start —
+    /// but the timeout alone looks identical to a slow host, and issue #33 was diagnosed
+    /// four steps below the actual cause because of it.
+    /// </summary>
+    private readonly RdpWrapper _rdpWrapper;
+
     // RDP loopback address — use 127.0.0.2 to avoid conflicts with 127.0.0.1/localhost
     private const string RdpLoopbackAddress = "127.0.0.2";
 
     public SessionLauncher(
         ILogger<SessionLauncher> logger,
         IOptions<MultiSeatOptions> options,
-        AccountManager accounts)
+        AccountManager accounts,
+        RdpWrapper rdpWrapper)
     {
         _logger = logger;
         _options = options.Value;
         _accounts = accounts;
+        _rdpWrapper = rdpWrapper;
         _credentials = new RdpCredentialStore(logger);
     }
 
@@ -558,14 +568,29 @@ public sealed class SessionLauncher
 
             if (sessionId < 0)
             {
+                // Ask WHY before listing remedies. Multi-session being unavailable is not one
+                // cause among four — it is the cause that makes the other three unreachable,
+                // and the reason lands in the log from EnsureMultiSession itself.
+                var multiSessionOk = _rdpWrapper.EnsureMultiSession();
+
                 throw new InvalidOperationException(
                     $"RDP loopback session for '{accountName}' did not appear within timeout. " +
-                    "Check the service log for the mstsc exit code logged above. " +
-                    "Steps to diagnose: " +
-                    "(1) Re-run prerequisites\\install-prerequisites.ps1 to refresh rdpwrap.ini for your Windows build. " +
-                    "(2) Open RDPConf.exe and verify Listener state is 'Listening [fully supported]'. " +
-                    "(3) Manually run: mstsc /v:127.0.0.2 and log in as the seat account to verify RDP works. " +
-                    "(4) Check HKLM\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp: UserAuthentication must be 0.");
+                    (multiSessionOk
+                        ? "Multi-session RDP checks out, so the wrapper is not the problem here. " +
+                          "Check the service log for the mstsc exit code logged above. " +
+                          "Steps to diagnose: " +
+                          "(1) Manually run: mstsc /v:127.0.0.2 and log in as the seat account to verify RDP works. " +
+                          "(2) Check HKLM\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp: " +
+                          "UserAuthentication must be 0."
+                        : "CAUSE: multi-session RDP is NOT available on this host — see the RDP Wrapper " +
+                          "lines logged just above for which check failed. Every seat is an RDP session, " +
+                          "so no seat can start until that is fixed, and the steps below are downstream of it. " +
+                          "Fix it with: " +
+                          "(1) Run prerequisites\\install-prerequisites.ps1 — it installs RDP Wrapper and " +
+                          "refreshes rdpwrap.ini for your Windows build. " +
+                          "(2) If it reports your build as uncovered, run scripts\\check-rdpwrap-offsets.ps1 " +
+                          "-Generate to compute the offsets locally, then -Apply to merge them in. " +
+                          "(3) Confirm with RDPConf.exe that Listener state reads 'Listening [fully supported]'."));
             }
 
             _logger.LogInformation(


### PR DESCRIPTION
Closes nothing yet — #33 is still waiting on the reporter's `check-rdpwrap-offsets.ps1` output. This fixes the gap that report exposed, which is real regardless of what caused their particular failure.

## The problem

Every seat is an RDP session, so an inactive RDP Wrapper means no seat can ever start. Nothing said so.

`install-service.ps1` gated on SudoVDA and on the audio cables, but said nothing about the one dependency without which nothing works at all. It would register and start the service on a host where seats were impossible, and the first sign the user got was a seat timing out. The timeout message then listed "refresh rdpwrap.ini" as step 1 of 4, alongside three steps that are downstream of it — so #33 was diagnosed four steps below the actual cause.

Before 0.6.0 this was masked. Installing meant cloning the repo, so `prerequisites\` was physically in front of you. The zip install removed the clone and took the reminder with it.

## install-service.ps1

A real check, placed before the SudoVDA one. It mirrors `RdpWrapper.EnsureMultiSession()` rather than reimplementing it, so the installer and the service cannot drift apart:

- both install shapes — `System32\rdpwrap.dll`, and a redirected `TermService\Parameters\ServiceDll`
- no requirement that the DLL be *named* rdpwrap, so TermWrap still passes. Demanding the name reported a working host as broken in #15
- `termsrv.dll` read from `FileVersionRaw`, never the version string, which disagrees with it
- both `[version]` and `[version-SLInit]` required — RDPWrap patches with whatever it finds, so a half-present pair is worse than none

It separates **not installed** from **installed but not covering this build**. The second is invisible from the outside and is the likelier case in #33. The verdict also reprints after `Service installed`, because a warning several screens above a success line is a warning nobody reads.

## SessionLauncher

The timeout now asks *why* before listing remedies. It calls `EnsureMultiSession()` on failure: if multi-session is broken, the exception leads with the cause and points at the wrapper lines already in the log; if it checks out, it says so and drops the two steps that are then irrelevant.

## Testing

Build clean, 0 errors. 508 tests pass, 0 fail, 17 skipped — all hardware-gated.

**Not runtime-tested, and not testable here.** The path that matters is installing onto a host whose `rdpwrap.ini` doesn't cover its `termsrv.dll`, which needs a machine in that broken state. `SessionLauncher_CreatesAndDestroysSession` is one of the 17 skips, so the new timeout branch has no test coverage either. Reviewer's attention is best spent on the detection logic matching `EnsureMultiSession()`.

Reported by @darkjezza in #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQvL62WkT8xDWXqyjFCGDw
