### PR TITLE
feat(streaming): identify Apollo by PID + start time, not PID alone

### DIFF
--- a/src/MultiSeat.Service/Streaming/ApolloManager.cs
+++ b/src/MultiSeat.Service/Streaming/ApolloManager.cs
@@ -110,6 +110,19 @@ public sealed class ApolloManager
             return pid;
         }
 
+        // Capture the OS start time NOW, while the process we just launched still owns the PID.
+        // Null means it was unreadable (already exited, or denied) — record no identity rather
+        // than a fabricated one, and log it, because it silently downgrades every later kill for
+        // this seat to the unverified path.
+        var osStartedAt = GetProcessStartTime(pid);
+        if (osStartedAt is null)
+        {
+            _logger.LogWarning(
+                "Seat {Id}: Apollo started (PID {Pid}) but its start time could not be read — " +
+                "no PID-reuse protection for this instance",
+                seat.Id, pid);
+        }
+
         var instance = new ApolloInstance(
             SeatId: seat.Id,
             ProcessId: pid,
@@ -117,7 +130,8 @@ public sealed class ApolloManager
             SessionId: seat.SessionId,
             AccountName: seat.AccountName,
             StartedAt: DateTimeOffset.UtcNow,
-            RestartCount: 0);
+            RestartCount: 0,
+            Identity: osStartedAt is { } t ? new ProcessIdentity(pid, t) : null);
 
         _instances[seat.Id] = instance;
 
@@ -140,23 +154,18 @@ public sealed class ApolloManager
 
         if (instance.ProcessId > 0)
         {
-            try
+            if (instance.Identity is { } identity)
             {
-                var proc = Process.GetProcessById(instance.ProcessId);
-                if (!proc.HasExited)
-                {
-                    proc.Kill(entireProcessTree: true);
-                    proc.WaitForExit(3000);
-                }
+                var outcome = TryKillIdentifiedProcess(
+                    identity, $"reconnect kill for seat {seat.Id}", waitMs: 3000);
                 _logger.LogInformation(
-                    "Seat {Id}: Apollo killed before reconnect (PID {Pid})",
-                    seat.Id, instance.ProcessId);
+                    "Seat {Id}: Apollo reconnect kill — {Outcome} (PID {Pid})",
+                    seat.Id, outcome, instance.ProcessId);
             }
-            catch (ArgumentException) { } // already exited
-            catch (Exception ex)
+            else
             {
-                _logger.LogWarning(ex,
-                    "Seat {Id}: error killing Apollo before reconnect", seat.Id);
+                KillUnidentifiedApollo(
+                    seat.Id, instance.ProcessId, "reconnect", waitMs: 3000);
             }
         }
 
@@ -170,29 +179,24 @@ public sealed class ApolloManager
     /// </summary>
     public void Stop(SeatInfo seat)
     {
-        _instances.TryRemove(seat.Id, out _);
+        // Keep the record rather than discarding it: it carries the ProcessIdentity, which is
+        // the only thing that can tell this seat's Apollo from a process that inherited its PID.
+        _instances.TryRemove(seat.Id, out var instance);
 
+        if (instance?.Identity is { } identity)
+        {
+            var outcome = TryKillIdentifiedProcess(
+                identity, $"stop for seat {seat.Id}", waitMs: 5000);
+            _logger.LogInformation("Seat {Id}: Apollo stop — {Outcome} (PID {Pid})",
+                seat.Id, outcome, identity.ProcessId);
+            return;
+        }
+
+        // No identity available. This is the path after a service restart, where the instance
+        // record is gone and SeatInfo carries only a bare PID. Carrying the identity on SeatInfo
+        // would close it, but that is a contract change and belongs to PR D (issue #29).
         if (seat.ApolloProcessId <= 0) return;
-
-        try
-        {
-            var proc = Process.GetProcessById(seat.ApolloProcessId);
-            if (!proc.HasExited)
-            {
-                proc.Kill(entireProcessTree: true);
-                proc.WaitForExit(5000);
-            }
-            _logger.LogInformation("Seat {Id}: Apollo stopped (PID {Pid})",
-                seat.Id, seat.ApolloProcessId);
-        }
-        catch (ArgumentException)
-        {
-            // Process already exited
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Seat {Id}: error stopping Apollo", seat.Id);
-        }
+        KillUnidentifiedApollo(seat.Id, seat.ApolloProcessId, "stop", waitMs: 5000);
     }
 
     /// <summary>
@@ -679,6 +683,152 @@ public sealed class ApolloManager
         name.Contains("VDD", StringComparison.OrdinalIgnoreCase) ||
         name.Contains("SudoVDA", StringComparison.OrdinalIgnoreCase) ||
         name.Contains("SudoMaker", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The OS-reported start time for a PID, used to build a <see cref="ProcessIdentity"/>.
+    /// Returns null when it cannot be read.
+    ///
+    /// ⛔ Callers must NOT substitute a fallback timestamp when this returns null. An identity
+    /// carrying a made-up start time compares equal to nothing real, or worse, compares equal to
+    /// a recycled PID by coincidence. No identity is honest; a fabricated one is not.
+    /// </summary>
+    internal static DateTimeOffset? GetProcessStartTime(int pid)
+    {
+        if (pid <= 0) return null;
+        try
+        {
+            using var proc = Process.GetProcessById(pid);
+            return proc.StartTime.ToUniversalTime();
+        }
+        catch (ArgumentException)
+        {
+            return null;    // PID does not exist — exited between launch and now
+        }
+        catch (InvalidOperationException)
+        {
+            return null;    // process object in an invalid state
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            return null;    // access denied or another OS error
+        }
+    }
+
+    /// <summary>
+    /// Kill a PID we have no <see cref="ProcessIdentity"/> for, after checking it at least still
+    /// names an Apollo. Used only where the identity is genuinely unavailable — after a service
+    /// restart, where the instance record is gone and only a bare PID survives on SeatInfo.
+    ///
+    /// ⚠️ This is WEAKER than the identity check and is not a substitute for it. A recycled PID
+    /// that happens to be another Apollo passes. It exists because the alternative in that path
+    /// was killing on PID alone, which passes for anything at all — a text editor, the user's
+    /// browser. Narrowing "any process" to "some Apollo" is the win; PR D closes the rest.
+    /// </summary>
+    private void KillUnidentifiedApollo(Guid seatId, int pid, string reason, int waitMs)
+    {
+        var expected = Path.GetFileNameWithoutExtension(_options.ApolloExePath);
+        try
+        {
+            using var proc = Process.GetProcessById(pid);
+            if (proc.HasExited) return;
+
+            if (!string.IsNullOrEmpty(expected) &&
+                !string.Equals(proc.ProcessName, expected, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning(
+                    "Seat {Id}: PID {Pid} is '{Actual}', not '{Expected}' — the PID was reused, " +
+                    "refusing to kill an unrelated process ({Reason})",
+                    seatId, pid, proc.ProcessName, expected, reason);
+                return;
+            }
+
+            proc.Kill(entireProcessTree: true);
+            proc.WaitForExit(waitMs);
+            _logger.LogInformation(
+                "Seat {Id}: Apollo PID {Pid} terminated by name match, unverified identity " +
+                "({Reason})", seatId, pid, reason);
+        }
+        catch (ArgumentException)
+        {
+            // PID free — nothing to do.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Seat {Id}: error stopping Apollo PID {Pid} ({Reason})",
+                seatId, pid, reason);
+        }
+    }
+
+    /// <summary>
+    /// Terminate the process named by <paramref name="identity"/>, but only while that PID still
+    /// denotes the exact recorded instance, via <see cref="ProcessIdentity.Matches"/>.
+    ///
+    /// ⭐ A single open handle spans verification through Kill, and that is what makes this
+    /// correct: Windows will not recycle a PID while a handle to its process object is open, so a
+    /// handle we verified cannot afterwards name a different process. Re-opening the process by
+    /// PID between the check and the kill would reintroduce exactly the race being closed.
+    ///
+    /// The residual race — the process exits between verify and kill — can only fail to kill the
+    /// RIGHT process, never kill the WRONG one. That is the direction to fail in. (Tree kills
+    /// share the runtime's inherent child-enumeration race with every other tree kill here; out
+    /// of scope.)
+    ///
+    /// Never throws.
+    /// </summary>
+    internal ApolloKillOutcome TryKillIdentifiedProcess(
+        ProcessIdentity identity, string reason, int waitMs)
+    {
+        try
+        {
+            using var proc = Process.GetProcessById(identity.ProcessId);
+            if (proc.HasExited)
+                return ApolloKillOutcome.AlreadyGone;
+
+            DateTimeOffset startedAt;
+            try
+            {
+                startedAt = proc.StartTime.ToUniversalTime();
+            }
+            catch (InvalidOperationException)
+            {
+                return ApolloKillOutcome.AlreadyGone;   // exited mid-check; fail closed
+            }
+            catch (System.ComponentModel.Win32Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Apollo PID {Pid} start time unreadable during {Reason} — leaving it alone " +
+                    "rather than killing a process we cannot identify",
+                    identity.ProcessId, reason);
+                return ApolloKillOutcome.IdentityMismatch;
+            }
+
+            if (!identity.Matches(identity.ProcessId, startedAt))
+            {
+                _logger.LogWarning(
+                    "Apollo PID {Pid} no longer names the recorded instance (recorded {Recorded}, " +
+                    "current {Current}) — the PID was reused, leaving the unrelated process " +
+                    "alone ({Reason})",
+                    identity.ProcessId, identity.StartedAt, startedAt, reason);
+                return ApolloKillOutcome.IdentityMismatch;
+            }
+
+            proc.Kill(entireProcessTree: true);
+            proc.WaitForExit(waitMs);
+            _logger.LogInformation("Apollo PID {Pid} terminated ({Reason})",
+                identity.ProcessId, reason);
+            return ApolloKillOutcome.Killed;
+        }
+        catch (ArgumentException)
+        {
+            return ApolloKillOutcome.AlreadyGone;   // PID free
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error terminating Apollo PID {Pid} ({Reason})",
+                identity.ProcessId, reason);
+            return ApolloKillOutcome.AlreadyGone;
+        }
+    }
 }
 
 /// <summary>
@@ -691,10 +841,16 @@ internal sealed record ApolloInstance(
     int SessionId,
     string AccountName,
     DateTimeOffset StartedAt,
-    int RestartCount)
+    int RestartCount,
+    ProcessIdentity? Identity = null)
 {
     /// <summary>
     /// Check if the Apollo process is still running.
+    ///
+    /// ⚠️ <see cref="StartedAt"/> above is OUR wall-clock stamp from the moment we recorded the
+    /// launch. It is NOT the OS process start time and must never be used for this comparison:
+    /// it cannot disagree with a recycled PID, so a check built on it always passes.
+    /// <see cref="Identity"/> carries the OS-reported time and is the one that can.
     /// </summary>
     public bool IsAlive
     {
@@ -704,7 +860,27 @@ internal sealed record ApolloInstance(
             try
             {
                 using var proc = Process.GetProcessById(ProcessId);
-                return !proc.HasExited;
+                if (proc.HasExited) return false;
+
+                // No identity recorded (start time was unreadable at launch): fall back to
+                // "the PID exists", which is what this did before identity existed. Reported
+                // alive here can mean a recycled PID, so callers that KILL must verify.
+                if (Identity is not { } identity) return true;
+
+                try
+                {
+                    return identity.Matches(ProcessId, proc.StartTime.ToUniversalTime());
+                }
+                catch (InvalidOperationException)
+                {
+                    return false;   // exited between HasExited and StartTime
+                }
+                catch (System.ComponentModel.Win32Exception)
+                {
+                    // Start time unreadable. Report alive rather than dead: a false "dead"
+                    // makes SessionHealthCheck restart a seat whose Apollo is running fine.
+                    return true;
+                }
             }
             catch (ArgumentException)
             {
@@ -712,4 +888,24 @@ internal sealed record ApolloInstance(
             }
         }
     }
+}
+
+/// <summary>
+/// What <see cref="ApolloManager.TryKillIdentifiedProcess"/> did. Every failure is an outcome
+/// rather than an exception so callers keep their contracts (idempotent stop, best-effort
+/// reconnect kill).
+/// </summary>
+internal enum ApolloKillOutcome
+{
+    /// <summary>The recorded instance was terminated.</summary>
+    Killed,
+
+    /// <summary>The PID is free or the process had already exited. Nothing to do.</summary>
+    AlreadyGone,
+
+    /// <summary>
+    /// The PID exists but names a different process than the one recorded, or its start time
+    /// could not be read. Nothing was killed — deliberately.
+    /// </summary>
+    IdentityMismatch
 }

--- a/src/MultiSeat.Shared/Models/ProcessIdentity.cs
+++ b/src/MultiSeat.Shared/Models/ProcessIdentity.cs
@@ -1,0 +1,52 @@
+namespace MultiSeat.Shared.Models;
+
+/// <summary>
+/// Value object that uniquely identifies a process instance, protecting against PID reuse.
+///
+/// A process ID alone is not an identity: Windows recycles PIDs, so a PID captured when a seat
+/// was provisioned may name a completely different process once the original exits. Pairing the
+/// PID with the OS-reported start time distinguishes the original from any later occupant.
+///
+/// INVARIANT: two <see cref="ProcessIdentity"/> values with the same PID but different
+/// <see cref="StartedAt"/> represent different process instances.
+///
+/// ⚠️ <see cref="StartedAt"/> is the time the OPERATING SYSTEM reports the process started
+/// (<c>Process.StartTime</c>), never the time we happened to record it. A wall-clock stamp taken
+/// at launch looks similar and is useless here — it cannot disagree with a recycled PID's real
+/// start time, so a check built on one silently always passes.
+///
+/// Ported from @Dani6ca-T's MultiSeat-Extended as the minimal primitive, without the process
+/// tracking subsystem built around it there. See issue #29.
+/// </summary>
+public readonly record struct ProcessIdentity : IComparable<ProcessIdentity>
+{
+    /// <summary>The operating system process ID.</summary>
+    public int ProcessId { get; init; }
+
+    /// <summary>
+    /// The UTC time the OS reports the process started. If a PID exists but its start time
+    /// differs from this, the PID was reused by a different process.
+    /// </summary>
+    public DateTimeOffset StartedAt { get; init; }
+
+    public ProcessIdentity(int processId, DateTimeOffset startedAt)
+    {
+        if (processId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(processId), processId,
+                "Process ID must be positive.");
+        ProcessId = processId;
+        StartedAt = startedAt;
+    }
+
+    /// <summary>
+    /// True when the given PID and start time name this exact instance. Used to detect PID
+    /// reuse: the PID existing is not enough, the start time has to agree too.
+    /// </summary>
+    public bool Matches(int pid, DateTimeOffset startTime) =>
+        ProcessId == pid && StartedAt == startTime;
+
+    public int CompareTo(ProcessIdentity other) =>
+        ProcessId.CompareTo(other.ProcessId);
+
+    public override string ToString() => $"PID {ProcessId} @ {StartedAt:O}";
+}

--- a/src/MultiSeat.Tests/Streaming/ProcessIdentityTests.cs
+++ b/src/MultiSeat.Tests/Streaming/ProcessIdentityTests.cs
@@ -1,0 +1,177 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiSeat.Service.Configuration;
+using MultiSeat.Service.Streaming;
+using MultiSeat.Shared.Models;
+using Xunit;
+
+namespace MultiSeat.Tests.Streaming;
+
+/// <summary>
+/// PID reuse: a PID captured when a seat was provisioned can name a completely different process
+/// once the original exits, because Windows recycles PIDs. Before <see cref="ProcessIdentity"/>,
+/// both of ApolloManager's kill paths did <c>Process.GetProcessById(pid).Kill(entireProcessTree)</c>
+/// with no check that the PID still meant what it did at launch — so a recycled PID meant killing
+/// a stranger's process tree, and nothing would have said so.
+///
+/// ⭐ <see cref="TryKillIdentifiedProcess_WithMismatchedStartTime_RefusesAndLeavesProcessRunning"/>
+/// is the test that matters. The others pin the primitive; that one proves the wrong process
+/// survives, which is the entire point of the change.
+///
+/// Ported as the minimal primitive from @Dani6ca-T's MultiSeat-Extended (issue #29, PR B) without
+/// the process-tracking subsystem built around it there.
+/// </summary>
+public class ProcessIdentityTests
+{
+    private sealed class NoopLogger<T> : ILogger<T>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => false;
+        public void Log<TState>(LogLevel l, EventId e, TState s, Exception? ex,
+            Func<TState, Exception?, string> f) { }
+    }
+
+    private static ApolloManager NewManager() => new(
+        new NoopLogger<ApolloManager>(),
+        Options.Create(new MultiSeatOptions()),
+        configBuilder: null!,      // untouched by the kill paths under test
+        processInjector: null!);
+
+    /// <summary>A real, long-lived child process to act on. Killed by the caller or by dispose.</summary>
+    private static Process StartVictim() =>
+        Process.Start(new ProcessStartInfo("ping.exe", "127.0.0.1 -n 120")
+        {
+            CreateNoWindow = true,
+            UseShellExecute = false,
+            RedirectStandardOutput = true
+        })!;
+
+    // ── the primitive ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_RejectsNonPositivePid()
+    {
+        var now = DateTimeOffset.UtcNow;
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ProcessIdentity(0, now));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ProcessIdentity(-1, now));
+    }
+
+    [Fact]
+    public void Matches_RequiresBothPidAndStartTime()
+    {
+        var started = DateTimeOffset.UtcNow;
+        var identity = new ProcessIdentity(1234, started);
+
+        Assert.True(identity.Matches(1234, started));
+        Assert.False(identity.Matches(1234, started.AddTicks(1)));   // the reuse case
+        Assert.False(identity.Matches(5678, started));
+    }
+
+    [Fact]
+    public void SamePidDifferentStartTime_AreNotEqual()
+    {
+        var started = DateTimeOffset.UtcNow;
+        Assert.NotEqual(
+            new ProcessIdentity(1234, started),
+            new ProcessIdentity(1234, started.AddSeconds(1)));
+    }
+
+    // ── reading the OS start time ───────────────────────────────────────────────
+
+    [Fact]
+    public void GetProcessStartTime_ReturnsUtcForALiveProcess()
+    {
+        using var self = Process.GetCurrentProcess();
+        var startedAt = ApolloManager.GetProcessStartTime(self.Id);
+
+        Assert.NotNull(startedAt);
+        Assert.Equal(TimeSpan.Zero, startedAt!.Value.Offset);   // must be UTC, not local
+    }
+
+    [Fact]
+    public void GetProcessStartTime_ReturnsNullForAFreePid()
+    {
+        // Never fabricate a timestamp when this fails — an identity carrying a made-up start
+        // time can compare equal to a recycled PID by coincidence.
+        Assert.Null(ApolloManager.GetProcessStartTime(0));
+        Assert.Null(ApolloManager.GetProcessStartTime(-1));
+    }
+
+    // ── the behaviour the change exists for ─────────────────────────────────────
+
+    [Fact]
+    public void TryKillIdentifiedProcess_WithMismatchedStartTime_RefusesAndLeavesProcessRunning()
+    {
+        using var victim = StartVictim();
+        try
+        {
+            var realStart = ApolloManager.GetProcessStartTime(victim.Id);
+            Assert.NotNull(realStart);
+
+            // Same PID, wrong start time — exactly what a recycled PID looks like.
+            var stale = new ProcessIdentity(victim.Id, realStart!.Value.AddSeconds(-30));
+
+            var outcome = NewManager().TryKillIdentifiedProcess(stale, "test", waitMs: 2000);
+
+            Assert.Equal(ApolloKillOutcome.IdentityMismatch, outcome);
+
+            // The point: the unrelated process is untouched. Before this change it was killed.
+            victim.Refresh();
+            Assert.False(victim.HasExited);
+        }
+        finally
+        {
+            if (!victim.HasExited) victim.Kill(entireProcessTree: true);
+        }
+    }
+
+    [Fact]
+    public void TryKillIdentifiedProcess_WithMatchingIdentity_Kills()
+    {
+        using var victim = StartVictim();
+        try
+        {
+            var realStart = ApolloManager.GetProcessStartTime(victim.Id);
+            Assert.NotNull(realStart);
+
+            var outcome = NewManager().TryKillIdentifiedProcess(
+                new ProcessIdentity(victim.Id, realStart!.Value), "test", waitMs: 5000);
+
+            Assert.Equal(ApolloKillOutcome.Killed, outcome);
+            victim.Refresh();
+            Assert.True(victim.HasExited);
+        }
+        finally
+        {
+            if (!victim.HasExited) victim.Kill(entireProcessTree: true);
+        }
+    }
+
+    [Fact]
+    public void TryKillIdentifiedProcess_WhenAlreadyExited_ReportsAlreadyGone()
+    {
+        var victim = StartVictim();
+        var realStart = ApolloManager.GetProcessStartTime(victim.Id);
+        Assert.NotNull(realStart);
+        var identity = new ProcessIdentity(victim.Id, realStart!.Value);
+
+        victim.Kill(entireProcessTree: true);
+        victim.WaitForExit(5000);
+        victim.Dispose();
+
+        var outcome = NewManager().TryKillIdentifiedProcess(identity, "test", waitMs: 1000);
+
+        // Either the PID is free, or it is held by something else and fails the identity check.
+        // Both are non-destructive; what must never happen is Killed.
+        Assert.NotEqual(ApolloKillOutcome.Killed, outcome);
+    }
+
+    [Fact]
+    public void TryKillIdentifiedProcess_NeverThrows()
+    {
+        var identity = new ProcessIdentity(int.MaxValue, DateTimeOffset.UtcNow);
+        var outcome = NewManager().TryKillIdentifiedProcess(identity, "test", waitMs: 1000);
+        Assert.Equal(ApolloKillOutcome.AlreadyGone, outcome);
+    }
+}


### PR DESCRIPTION
**PR B of the #29 sequence.** The minimal process-identity primitive, without the process-tracking subsystem built around it in the fork.

Ported from work by @Dani6ca-T in [`MultiSeat-Extended`](https://github.com/Dani6ca-T/MultiSeat-Extended).

## The hole

Windows recycles PIDs. Both of `ApolloManager`'s kill paths did:

```csharp
Process.GetProcessById(pid).Kill(entireProcessTree: true);
```

with no check that the PID still meant what it did at launch. A recycled PID meant killing a stranger's entire process tree, and nothing would have said so. `IsAlive` had the same hole pointing the other way: "the PID exists" reported a seat healthy when its Apollo was long gone and something unrelated had inherited the number.

## What landed

`ProcessIdentity` — PID + OS start time + `Matches` — is ported as-is. No `IProcessTracker`, no `ProcessTracking` namespace, none of the surrounding architecture. That separation is the point of B.

**Verified kill through one handle.** `TryKillIdentifiedProcess` verifies and kills through a *single* open handle. Windows will not recycle a PID while a handle to its process object is open, so a handle we verified cannot afterwards name a different process. Re-opening by PID between the check and the kill would reintroduce exactly the race being closed. The residual race — the process exits between verify and kill — can only fail to kill the *right* process, never kill the *wrong* one.

**A trap worth naming.** `ApolloInstance` already had a `StartedAt`, but it is *our* wall-clock stamp from when we recorded the launch, not the OS start time. It can never disagree with a recycled PID, so a check built on it passes 100% of the time while looking correct. Both sites are commented so the next reader does not reach for it.

**Fails closed, never fabricates.** If the start time is unreadable at launch, no identity is recorded rather than one carrying a placeholder — a made-up timestamp can compare equal to a recycled PID by coincidence. It logs a warning, because it silently downgrades every later kill for that seat.

## One deliberate gap

`Stop` can run with no instance record — after a service restart, only a bare PID survives on `SeatInfo`. The fork closes this by carrying the identity on `SeatInfo`, but **that is a contract change and belongs to PR D**, so it is not here.

Instead `KillUnidentifiedApollo` checks the PID still names an Apollo before killing. This is **weaker, not equivalent**: a recycled PID that happens to be another Apollo passes it. It narrows "kill any process at all" to "kill some Apollo" — a real improvement on that path, not the fix. PR D closes the rest.

## Testing

9 new tests. 517 passing, 0 failing, 17 skipped (all pre-existing hardware gates). No regressions.

The load-bearing test asserts a mismatched identity leaves the victim process **running**. It is paired with a matching-identity test asserting the same kind of process **is** killed. That pairing is deliberate: a guard that silently did nothing would pass a lone "still alive" assertion, so the control is what makes the result mean anything.

## Sequence

PR A merged as #27. This is B. C (teardown guards on `SeatLifecycleGate`) and D (API contract changes) remain — see #29, whose ordering was re-verified against `master` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQvL62WkT8xDWXqyjFCGDw
