### PR TITLE
fix(seats): the teardown warning overstated the stall

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,9 +342,15 @@ MultiSeat is self-contained and **non-destructive**: it works out of the box whe
 2. **Own port range.** Default `PortBase = 48100`, above a stock Apollo's block — no runtime port conflict.
 3. **Never kills a non-MultiSeat Apollo.** On startup `MultiSeatWorker.KillOrphanedApolloProcesses` reaps **only** Apollo processes MultiSeat launched, identified via WMI (`GetManagedApolloPids`) by executable path (under the ApolloVibe dir) or a MultiSeat per-seat config path on the command line. It no longer stops/disables `ApolloService`, and `install-service.ps1` leaves that service alone. (WMI failure → empty set → cleanup is skipped rather than risk killing an unrelated Apollo.)
 
-⚠️ **"Non-destructive" has one exception, and it is not fixable here: tearing a seat down stalls a
-standalone Apollo's stream for about 690 ms** while it rebuilds its encoder. Self-recovering, and
-it does not compound with seat count — seat-to-seat interference was measured and does not exist.
+⚠️ **"Non-destructive" has one exception, and it is not fixable here: tearing a seat down makes a
+standalone Apollo rebuild its encoder.** Self-recovering, and it does not compound with seat count —
+seat-to-seat interference was measured and does not exist.
+
+⭐ **It is smaller than it sounds.** 690 ms on 2026-09-04, **266 ms on 2026-09-11**, and on
+2026-09-11 the person actually streaming **did not notice it at all**. Do not describe this as a
+freeze or a second-long stall; that came from one early measurement and overstates it. ⚠️ One
+user's perception on one LAN is not proof it is always imperceptible — but "a few hundred
+milliseconds, usually unnoticed" is what the evidence supports.
 
 ⛔ **The cause is NOT a second Apollo starting or stopping**, which is the intuitive guess and was
 this issue's original premise. Decomposed step by step (#23): stopping the seat's Apollo produced

--- a/src/MultiSeat.Service/Sessions/SeatManager.cs
+++ b/src/MultiSeat.Service/Sessions/SeatManager.cs
@@ -649,8 +649,8 @@ public sealed class SeatManager
                 _logger.LogWarning(
                     "Seat {Id}: tearing down while the standalone Apollo (PID {Pid}, {Name}) is " +
                     "streaming. Ending this seat's RDP session changes the desktop topology, so " +
-                    "that stream will stall for about a second while its encoder rebuilds. It " +
-                    "recovers on its own. See issue #23.",
+                    "that stream will hitch for a few hundred milliseconds while its encoder " +
+                    "rebuilds. It recovers on its own. See issue #23.",
                     seatId, host.ProcessId, host.HostName ?? "unnamed");
             }
         }


### PR DESCRIPTION
The warning shipped in #50 said the standalone Apollo's stream "will stall for about a second". Verified on the reference host today, and that is wrong in the direction that matters — it makes operators expect something worse than what happens.

## Measured with a client genuinely streaming

```
08:49:23.503  warning fired
08:49:24.661  Apollo: Creating encoder      <- 1.2s AFTER the warning
08:49:25.099  Session 8 logged off
08:49:31.996  Apollo: Creating encoder      <- 7s after teardown, unexplained
```

The rebuild took **266 ms**, against the 690 ms measured on 2026-09-04 — and **the person streaming did not notice it at all.**

So: *"hitch for a few hundred milliseconds"*, not *"stall for about a second"*. `CLAUDE.md` carries the same correction, with both measurements and the caveat that one user's perception on one LAN does not prove it is always imperceptible.

## What else this run settled

**The warning fires before the stall**, by 1.2 seconds. That was the entire reason for placing it ahead of the lifecycle gate, and it is now observed rather than assumed.

**Provisioning did not cause a rebuild.** The RDP session was created at `08:49:09.933` with no encoder activity anywhere near it, which *supports* the original observation in #23 rather than contradicting it.

⚠️ An earlier reading of mine claimed provisioning *did* cause one — that was wrong, from eyeballing a log tail instead of correlating timestamps against the service log. Corrected before it reached the issue.

**One thing remains unexplained:** a second encoder rebuild seven seconds after teardown completed, with no MultiSeat activity near it. Possibly the client, possibly a delayed topology settle. Recorded rather than guessed at.

546 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQvL62WkT8xDWXqyjFCGDw
