### PR TITLE
ci: stop a registry outage failing the dashboard audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,41 @@ jobs:
       # `npm audit fix` (which cleared all 11 here without touching package.json), and if a
       # finding genuinely does not apply, record why with `npm audit --json` in the PR rather
       # than lowering this threshold.
+      #
+      # ⛔ But "found vulnerabilities" and "could not check" are NOT the same thing, and npm
+      # exits 1 for both. On 2026-09-11 master went red on:
+      #
+      #     npm warn audit 400 Bad Request - POST .../security/audits/quick
+      #     message: 'Invalid package tree, run npm install to rebuild your package-lock.json'
+      #     npm error audit endpoint returned an error
+      #
+      # The same commit had passed this job on its PR 45 minutes earlier and passed locally
+      # afterwards, so that was the registry, not the lockfile. Failing the build on it makes
+      # CI hostage to npmjs.org availability and turns this into exactly the intermittently
+      # red check that teaches people to ignore CI -- the thing build.yml was deleted for in
+      # MoonlightVibe.
+      #
+      # So: retry a transport error, and warn rather than fail if it persists. A real finding
+      # still fails on the first attempt.
       - name: Audit
-        run: npm audit --audit-level=high
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if out=$(npm audit --audit-level=high 2>&1); then
+              echo "$out"
+              exit 0
+            fi
+            echo "$out"
+            if echo "$out" | grep -qiE "audit endpoint returned an error|Bad Request|ENOTFOUND|ETIMEDOUT|EAI_AGAIN|socket hang up"; then
+              echo "::notice::npm audit could not reach the registry (attempt ${attempt}/3) — retrying"
+              sleep $((attempt * 10))
+              continue
+            fi
+            # Not a transport problem: npm found something at or above the threshold.
+            echo "::error::npm audit reported vulnerabilities at high severity or above"
+            exit 1
+          done
+          echo "::warning::npm audit could not reach the registry after 3 attempts. Dependencies were NOT audited in this run — check manually before relying on it."
 
   lint-scripts:
     name: Script lint (PowerShell 5.1 + 7)


### PR DESCRIPTION
`master` went red on `45f46b05`, and it was **not our code**:

```
npm warn audit 400 Bad Request - POST .../security/audits/quick
  message: 'Invalid package tree, run npm install to rebuild your package-lock.json'
npm error audit endpoint returned an error
```

## Why that is the registry and not the lockfile

- the **same commit passed this job on its own PR** 45 minutes earlier
- `npm ci && npm audit --audit-level=high` passes **locally** on that exact lockfile: `found 0 vulnerabilities`, exit 0, lockfile unchanged afterwards

So the 400 came from `registry.npmjs.org`.

## The actual defect, which is mine

`npm` exits 1 **both** for "found vulnerabilities at or above the threshold" **and** for "could not reach the audit endpoint". The original step treated those as the same thing.

When I added this gate I wrote that an upstream advisory breaking CI was "the intended behaviour, not a bug" — and it is. But I never separated a finding from a failure to check, which made CI hostage to npmjs.org availability and turned this into an **intermittently red check**.

That is the exact failure mode `build.yml` was deleted for in MoonlightVibe, and the reason given there was that a check nobody trusts is worse than no check. Same mistake, different repo, three hours apart.

## What changes

- a **transport error** is retried three times with backoff
- if the registry still cannot be reached, the step **warns and passes**, stating plainly that dependencies were not audited in that run
- a **real finding still fails on the first attempt**, unchanged

⚠️ The warning path means a run can be green without having audited anything. That is the lesser evil against a red build caused by someone else's outage, but it is a real gap — so the message says so rather than passing quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQvL62WkT8xDWXqyjFCGDw
